### PR TITLE
CI: add Gradle Maven mirror for plugin downloads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,20 +54,19 @@ jobs:
           mkdir -p ~/.gradle/init.d
           cat > ~/.gradle/init.d/maven-mirror.gradle <<'EOF'
           def mirrorUrl = 'https://maven-central.storage-download.googleapis.com/maven2'
-          gradle.beforeProject { project ->
-            project.buildscript.repositories {
-              maven { url mirrorUrl }
-            }
-            project.repositories {
-              maven { url mirrorUrl }
-            }
-          }
           gradle.settingsEvaluated { settings ->
             settings.pluginManagement.repositories {
               maven { url mirrorUrl }
               gradlePluginPortal()
               google()
               mavenCentral()
+            }
+            settings.dependencyResolutionManagement {
+              repositories {
+                maven { url mirrorUrl }
+                google()
+                mavenCentral()
+              }
             }
           }
           EOF


### PR DESCRIPTION
Problem
- Android CI fails fetching Kotlin artifacts with 403 from Maven Central.

Change
- Add a Gradle init script in CI to prefer a Maven Central mirror for plugin/buildscript/project repositories.

Why
- Avoids intermittent 403s from repo.maven.apache.org in GitHub Actions without touching Gradle files.
