### PR TITLE
Fix SOS numbers, country selection, and tests

### DIFF
--- a/lib/EmergencyNumbers.dart
+++ b/lib/EmergencyNumbers.dart
@@ -65,10 +65,11 @@ final Map<String, Country> countries = {
     {
       "name": "ער\"ן",
       "number": "1201",
+      "whatsappNumber": "972528451201",
       "link": "",
       "description": "טלפון-1201/מחו\"ל-*2201 | שלוחה 5",
       "icon": Icons.phone,
-      "whatsapp": false,
+      "whatsapp": true,
       "canCall": true,
     },
     {

--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -72,7 +72,9 @@ class _MenuState extends LPExtendedState<Menu> {
     var location =
         await service.getItem("location", PersistentMemoryType.String);
 
-    debugPrint(location);
+    if (location != null && location.toString().isNotEmpty) {
+      debugPrint(location.toString());
+    }
   }
 
 //Function to check if the user wants to go full screen

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -70,7 +70,6 @@ class _HomeState extends LPExtendedState<Home> {
   @override
   void initState() {
     loadData();
-    checkLanguage("a");
     super.initState();
   }
 
@@ -119,16 +118,6 @@ class _HomeState extends LPExtendedState<Home> {
           homeTitles = {'SubTitle': '', 'list': []};
         });
     }
-  }
-
-  void checkLanguage(String string) {
-    final regex = RegExp(r'[a-z]');
-    final regexHebrew = RegExp(r'[\u0590-\u05FF]');
-    if (regexHebrew.hasMatch("a"))
-      debugPrint("has match");
-    else
-      debugPrint("no match");
-    // return regex.hasMatch(input);
   }
 
   @override

--- a/lib/util/Phone/EmergencyPhones.dart
+++ b/lib/util/Phone/EmergencyPhones.dart
@@ -74,6 +74,7 @@ class EmergencyPhoneItem extends StatelessWidget {
           builder: (BuildContext context) {
             return EmergencyDialogBox(
               number: number["number"],
+              whatsappNumber: number["whatsappNumber"] ?? number["number"],
               link: number["link"],
               hasWhatsApp: number["whatsapp"],
               hasLink: number["link"] != "",

--- a/lib/util/Phone/emergencyDialogBox.dart
+++ b/lib/util/Phone/emergencyDialogBox.dart
@@ -12,6 +12,7 @@ import 'package:mazilon/l10n/app_localizations.dart';
 // This widget is a dialog box for making emergency phone calls and sending WhatsApp messages.
 class EmergencyDialogBox extends StatelessWidget {
   final String number; // The phone number to dial or message
+  final String whatsappNumber;
   final String
       link; // Index used to retrieve appropriate text from AppInformation
   final bool hasWhatsApp;
@@ -20,6 +21,7 @@ class EmergencyDialogBox extends StatelessWidget {
   const EmergencyDialogBox(
       {super.key,
       required this.number,
+      required this.whatsappNumber,
       required this.link,
       required this.hasWhatsApp,
       required this.canCall,
@@ -56,7 +58,7 @@ class EmergencyDialogBox extends StatelessWidget {
                   ),
                 if (hasWhatsApp)
                   getTextIconWidget(appLocale!.whatsApp, () async {
-                    await openWhatsApp(number);
+                    await openWhatsApp(whatsappNumber);
                   }, Icons.chat),
 
                 if (hasLink)

--- a/lib/util/Share/LP_alert_dialog_box_item.dart
+++ b/lib/util/Share/LP_alert_dialog_box_item.dart
@@ -31,11 +31,13 @@ class LPAlertDialogBoxItem extends StatelessWidget {
         children: [
           SizedBox(width: 10.0),
           Icon(icon, color: Colors.black, size: 30.sp),
-          TextButton(
-            onPressed: press,
-            child: Text(
-              buttonText,
-              style: TextStyle(color: Colors.black, fontSize: 13.sp),
+          Expanded(
+            child: TextButton(
+              onPressed: press,
+              child: Text(
+                buttonText,
+                style: TextStyle(color: Colors.black, fontSize: 13.sp),
+              ),
             ),
           ),
         ],

--- a/syncing.md
+++ b/syncing.md
@@ -1,0 +1,167 @@
+# Syncing Across Devices (Technical Brainstorm)
+
+## Scope and goals
+- Recover user data on a new device after loss or reinstall.
+- Keep multiple devices consistent without manual export/import.
+- Work offline and converge when connectivity returns.
+- Avoid data loss and avoid leaking sensitive data.
+- Keep changes minimal and incremental in code once implemented.
+
+## Existing storage surfaces (from code)
+- Local key/value: `PersistentMemoryService` wraps SharedPreferences in `lib/util/persistent_memory_service.dart`.
+- User state: `UserInformation` in `lib/util/userInformation.dart`.
+- Local files: `lib/file_service.dart` and `lib/util/PDF/create_pdf.dart`.
+- Firebase already in use: Auth + Firestore access in `lib/util/Firebase/firebase_functions.dart`.
+
+### Local keys currently stored (examples)
+- Identity and profile: `name`, `gender`, `binary`, `age`, `userId`, `loggedIn`.
+- Locale and location: `localeName`, `location`.
+- Flags: `enteredBefore`, `hasFilled`, `disclaimerConfirmed`.
+- Notifications: `notificationHour`, `notificationMinute`.
+- Personal plan lists:
+  - `userSelectionPersonalPlan-DifficultEvents`
+  - `userSelectionPersonalPlan-MakeSafer`
+  - `userSelectionPersonalPlan-FeelBetter`
+  - `userSelectionPersonalPlan-Distractions`
+- Other lists: `positiveTraits`, `thankYous`, `dates`.
+- Phone page:
+  - `PhonePageSavedPhoneNames`, `PhonePageSavedPhoneNumbers`
+  - `*SavedPhoneNames`, `*SavedPhoneNumbers` in `lib/util/Form/formPagePhoneModel.dart`.
+
+## Identity and account model
+1) Firebase Auth (recommended for recovery)
+   - Email/password, phone, Google/Apple as providers.
+   - Stable `uid` is the primary key for all sync.
+2) Anonymous first, upgrade later
+   - Anonymous `uid` to store data on day 1.
+   - On upgrade, migrate user doc to permanent account.
+3) Device pairing (optional, layered on top)
+   - QR code or one-time code to link a new device to an existing `uid`.
+   - Can be used even without full login if privacy requirements allow it.
+
+## Data model (Firestore + Storage)
+Store structured data in Firestore and large files in Firebase Storage.
+
+### Core user document
+```
+users/{uid}
+  schemaVersion: 1
+  createdAt: serverTimestamp
+  updatedAt: serverTimestamp
+  profile:
+    name, gender, binary, age, localeName, location
+  settings:
+    notificationHour, notificationMinute
+  flags:
+    hasFilled, enteredBefore, disclaimerConfirmed
+  deviceState:
+    lastDeviceId, lastAppVersion, lastSyncAt
+```
+
+### Lists as subcollections (merge-friendly)
+```
+users/{uid}/lists/{listId}
+  listType: "makeSafer" | "difficultEvents" | ...
+  updatedAt: serverTimestamp
+
+users/{uid}/lists/{listId}/items/{itemId}
+  value: string
+  createdAt: serverTimestamp
+  updatedAt: serverTimestamp
+  deletedAt: timestamp | null
+  sourceDeviceId: string
+```
+
+### Phone page custom contacts
+```
+users/{uid}/phones/{phoneId}
+  name: string
+  number: string
+  createdAt, updatedAt, deletedAt
+```
+
+### Files (PDFs, images)
+```
+users/{uid}/files/{fileId}
+  storagePath: "users/{uid}/files/{fileId}"
+  fileType: "pdf" | "image"
+  createdAt, updatedAt, deletedAt
+  metadata: sizeBytes, mimeType, originalName
+```
+
+## Sync engine and flow
+### Local first, remote second
+- Always write to local storage immediately.
+- Enqueue a sync event for remote.
+- If offline, keep the queue; retry with exponential backoff.
+
+### Pull and merge
+- On sign-in, pull remote data.
+- Merge into local using conflict rules (below).
+- Save merged state locally and update UI.
+
+### Push
+- Process queued changes with batched writes.
+- Use Firestore transactions when needed for per-item merges.
+
+### Suggested SyncEvent shape
+```
+SyncEvent {
+  id: string,
+  type: "set" | "add" | "remove",
+  entity: "profile" | "listItem" | "phone" | "file",
+  path: string,
+  payload: map,
+  localUpdatedAt: iso8601
+}
+```
+
+## Conflict resolution
+- Primitive fields: last-write-wins using `updatedAt`.
+- Lists:
+  - Each item has stable `itemId`.
+  - Use `updatedAt` to resolve per-item conflicts.
+  - Deletions use `deletedAt` tombstones.
+- If there is no matching country or list definition, log and keep local state.
+- Keep a `schemaVersion` for future migrations.
+
+## Offline and connectivity
+- Use Firestore offline persistence for structured data.
+- Local queue is the source of truth for unsynced writes.
+- On web, offline persistence is limited; keep local cache in memory + local storage.
+
+## Security and privacy
+- Firestore rules: users can only read/write their own data.
+- Optional client-side encryption for sensitive fields.
+  - Store encryption key in `flutter_secure_storage`.
+  - If key is lost, recovery is not possible; decide policy early.
+- Allow user to opt out of sync or select which data to sync.
+
+## Observability
+- Log sync failures to Sentry with `uid`, event id, and error code.
+- Store `lastSyncAt` and show it in Settings.
+- Add "Sync now" button for manual retries.
+
+## Recovery and restore flows
+- "Restore from account" option on first launch.
+- Offer a one-time merge: choose remote, local, or merge.
+- Optional export to encrypted JSON for offline backup.
+
+## Incremental implementation plan (minimal changes)
+1) Add a SyncService that mirrors existing `PersistentMemoryService` keys to Firestore.
+2) Implement basic pull on login (profile + flags + settings).
+3) Add list item sync with per-item IDs and tombstones.
+4) Add file sync via Firebase Storage.
+5) Add UI surface in Settings (status, manual sync, sign out).
+
+## Testing plan
+- Two emulators on same account; verify data propagates.
+- Offline edits on device A, then online; ensure merge on device B.
+- Conflict test: edit same list item on two devices; verify LWW rule.
+- Delete propagation: delete on A, verify deletion on B.
+
+## Open questions
+- Which data is too sensitive to sync (or should be opt-in)?
+- Should sync require login or allow anonymous + recovery code?
+- What is the expected maximum size of lists and files?
+- Do we need full audit history or only latest state?

--- a/test/MenuTest/Feelgood/feelGood_test.dart
+++ b/test/MenuTest/Feelgood/feelGood_test.dart
@@ -114,12 +114,18 @@ void main() {
       when(mockSharedPreferences.getBool('enteredBefore')).thenReturn(false);
     });
 
+    Future<void> tapAndSettle(WidgetTester tester, Finder finder) async {
+      await tester.ensureVisible(finder);
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+      await tester.tap(finder);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+    }
+
     testWidgets('Navigate to FeelGood screen', (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
 
-      await tester.tap(find.text('להרגיש טוב'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.text('להרגיש טוב'));
       expect(find.byType(FeelGood), findsOneWidget);
       expect(find.byType(ImageAddItem), findsWidgets);
       expect(find.byType(ImageDisplay), findsNothing);
@@ -129,27 +135,19 @@ void main() {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
 
-      await tester.tap(find.text('תפריט'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-      expect(find.byType(FractionallySizedBox), findsOneWidget);
-      await tester.tap(find.text('להרגיש טוב'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-      await tester.tap(find.text('בית'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.text('להרגיש טוב'));
+      await tapAndSettle(tester, find.text('בית'));
       expect(find.byType(Home), findsOneWidget);
     });
     testWidgets('Test adding photo from Camera', (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
 
-      await tester.tap(find.text('להרגיש טוב'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.text('להרגיש טוב'));
       expect(find.byKey(const Key("addImgButtonText")), findsOneWidget);
-      await tester.tap(find.byKey(const Key("addImgButtonText")));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.byKey(const Key("addImgButtonText")));
       expect(find.byKey(const Key("cameraButtonText")), findsOneWidget);
-      await tester.tap(find.byKey(const Key("cameraButtonText")));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.byKey(const Key("cameraButtonText")));
       expect(find.text('added'), findsWidgets);
       expect(find.byType(ImageDisplay), findsOneWidget);
       expect(find.byType(ImageAddItem), findsOneWidget);
@@ -158,13 +156,10 @@ void main() {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
 
-      await tester.tap(find.text('להרגיש טוב'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-      await tester.tap(find.byKey(const Key("addImgButtonText")));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.text('להרגיש טוב'));
+      await tapAndSettle(tester, find.byKey(const Key("addImgButtonText")));
       expect(find.byKey(const Key("galleryButtonText")), findsOneWidget);
-      await tester.tap(find.byKey(const Key("galleryButtonText")));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.byKey(const Key("galleryButtonText")));
       expect(find.text('added'), findsWidgets);
       expect(find.byType(ImageDisplay), findsOneWidget);
       expect(find.byType(ImageAddItem), findsOneWidget);
@@ -173,21 +168,14 @@ void main() {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
 
-      await tester.tap(find.text('להרגיש טוב'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-
-      await tester.tap(find.byKey(const Key("addImgButtonText")));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-      await tester.tap(find.byKey(const Key("cameraButtonText")));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-      await tester.tap(find.text('added'));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.text('להרגיש טוב'));
+      await tapAndSettle(tester, find.byKey(const Key("addImgButtonText")));
+      await tapAndSettle(tester, find.byKey(const Key("cameraButtonText")));
+      await tapAndSettle(tester, find.text('added'));
       expect(find.byKey(const Key('deleteButtonIcon')), findsOneWidget);
-      await tester.tap(find.byKey(const Key('deleteButtonIcon')));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.byKey(const Key('deleteButtonIcon')));
       expect(find.byKey(const Key('deleteButtonText')), findsOneWidget);
-      await tester.tap(find.byKey(const Key('deleteButtonText')));
-      await tester.pumpAndSettle(const Duration(seconds: 1));
+      await tapAndSettle(tester, find.byKey(const Key('deleteButtonText')));
       expect(find.text('added'), findsNothing);
       expect(find.byType(ImageDisplay), findsNothing);
       expect(find.byType(ImageAddItem), findsWidgets);

--- a/test/MenuTest/Wellness/wellnessTools_test.dart
+++ b/test/MenuTest/Wellness/wellnessTools_test.dart
@@ -91,52 +91,47 @@ void main() {
 
       when(mockSharedPreferences.getBool('enteredBefore')).thenReturn(false);
     });
+    Future<void> tapAndSettle(WidgetTester tester, Finder finder) async {
+      await tester.ensureVisible(finder);
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+      await tester.tap(finder);
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+    }
     testWidgets('Navigate to WellnessTools screen',
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tester.tap(find.text('תפריט'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('תפריט'));
       expect(find.byType(FractionallySizedBox), findsOneWidget);
-      await tester.tap(find.text('כלי תמיכה'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.byType(WellnessTools), findsOneWidget);
     });
     testWidgets('Navigate from WellnessTools screen',
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tester.tap(find.text('תפריט'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('תפריט'));
 
-      await tester.tap(find.text('כלי תמיכה'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('בית'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('כלי תמיכה'));
+      await tapAndSettle(tester, find.text('בית'));
       expect(find.byType(Home), findsOneWidget);
     });
     testWidgets('Test Repeated Navigation to and from WellnessTools screen',
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tester.tap(find.text('תפריט'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('תפריט'));
 
-      await tester.tap(find.text('כלי תמיכה'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.byType(WellnessTools), findsOneWidget);
-      await tester.tap(find.text('בית'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('בית'));
       expect(find.byType(WellnessTools), findsNothing);
       expect(find.byType(Home), findsOneWidget);
-      await tester.tap(find.text('תפריט'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('כלי תמיכה'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('תפריט'));
+      await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.byType(Home), findsNothing);
       expect(find.byType(WellnessTools), findsOneWidget);
-      await tester.tap(find.text('בית'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('בית'));
       expect(find.byType(Home), findsOneWidget);
       expect(find.byType(WellnessTools), findsNothing);
     });
@@ -144,11 +139,9 @@ void main() {
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tester.tap(find.text('תפריט'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('תפריט'));
 
-      await tester.tap(find.text('כלי תמיכה'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.byType(FakeVideoPlayerPage), findsOneWidget);
       expect(find.byType(MoreVideosItem), findsWidgets);
       expect(find.byKey(const Key("Image")), findsOneWidget);
@@ -157,11 +150,9 @@ void main() {
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tester.tap(find.text('תפריט'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('תפריט'));
 
-      await tester.tap(find.text('כלי תמיכה'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.text("Image"), findsOneWidget);
       expect(find.text('v1'), findsOneWidget);
       expect(find.text('v2'), findsOneWidget);
@@ -171,13 +162,10 @@ void main() {
     testWidgets('Test change video', (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tester.tap(find.text('תפריט'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('תפריט'));
 
-      await tester.tap(find.text('כלי תמיכה'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('v2'));
-      await tester.pumpAndSettle();
+      await tapAndSettle(tester, find.text('כלי תמיכה'));
+      await tapAndSettle(tester, find.text('v2'));
       expect(find.text("Image"), findsOneWidget);
       expect(find.text('v1'), findsOneWidget);
       expect(find.text('v2'), findsOneWidget);

--- a/test/MenuTest/shareAndDownload/share_and_download_test.dart
+++ b/test/MenuTest/shareAndDownload/share_and_download_test.dart
@@ -90,6 +90,12 @@ void main() {
       getData(mockAppInformation);
       when(mockSharedPreferences.getBool('enteredBefore')).thenReturn(false);
     });
+    Future<void> tapAndSettle(WidgetTester tester, Finder finder) async {
+      await tester.ensureVisible(finder);
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+      await tester.tap(finder);
+      await tester.pumpAndSettle(const Duration(milliseconds: 200));
+    }
     testWidgets('Display exists', (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
@@ -110,16 +116,14 @@ void main() {
       expect(find.byIcon(Elusive.share), findsOneWidget);
       expect(counterDownload, 0);
       expect(counterShare, 0);
-      await tester.tap(find.byIcon(Icons.download));
-      await tester.pump();
+      await tapAndSettle(tester, find.byIcon(Icons.download));
 
       expect(counterDownload, 1);
-      await tester.tap(find.byIcon(Elusive.share));
-      await tester.pump();
+      await tapAndSettle(tester, find.byIcon(Elusive.share));
       expect(find.byType(LPShareAlertDialog), findsWidgets);
       expect(find.byIcon(Icons.insert_drive_file_outlined), findsWidgets);
-      await tester.tap(find.text("שיתוף קובץ של התוכנית האישית"));
-      await tester.pump();
+      await tapAndSettle(
+          tester, find.text("שיתוף קובץ של התוכנית האישית"));
       expect(counterShare, 1);
     });
   });

--- a/test/country_selector_widget_test.dart
+++ b/test/country_selector_widget_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mazilon/global_enums.dart';
+import 'package:mazilon/initialForm/CountrySelectorWidget.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
+import 'package:mazilon/util/persistent_memory_service.dart';
+import 'package:mazilon/util/userInformation.dart';
+import 'package:provider/provider.dart';
+
+class InMemoryPersistentMemoryService implements PersistentMemoryService {
+  final Map<String, dynamic> _store = {};
+
+  @override
+  Future<void> setItem(String key, PersistentMemoryType type, dynamic value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<dynamic> getItem(String key, PersistentMemoryType type) async {
+    return _store[key];
+  }
+
+  @override
+  Future<void> reset() async {
+    _store.clear();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    GetIt.instance.registerSingleton<PersistentMemoryService>(
+        InMemoryPersistentMemoryService());
+  });
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  testWidgets('Country selector defaults to locale when location is empty',
+      (WidgetTester tester) async {
+    tester.binding.platformDispatcher.localeTestValue =
+        const Locale('en', 'US');
+    addTearDown(() {
+      tester.binding.platformDispatcher.clearLocaleTestValue();
+    });
+    final userInfo = UserInformation(service: InMemoryPersistentMemoryService());
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<UserInformation>.value(value: userInfo),
+        ],
+        child: ScreenUtilInit(
+          designSize: const Size(360, 690),
+          child: MaterialApp(
+            supportedLocales: AppLocalizations.supportedLocales,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            locale: const Locale('en', 'US'),
+            home: Scaffold(
+              body: CountrySelectorWidget(
+                text: 'Country/Region',
+                disclaimerText: '',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(userInfo.location, 'US');
+  });
+}

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mazilon/EmergencyNumbers.dart';
+import 'package:mazilon/global_enums.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
+import 'package:mazilon/util/Phone/emergencyDialogBox.dart';
+import 'package:mazilon/util/appInformation.dart';
+import 'package:mazilon/util/persistent_memory_service.dart';
+import 'package:mazilon/util/userInformation.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class FakePersistentMemoryService implements PersistentMemoryService {
+  @override
+  Future<dynamic> getItem(String key, PersistentMemoryType type) async {
+    return null;
+  }
+
+  @override
+  Future<void> reset() async {}
+
+  @override
+  Future<void> setItem(String key, PersistentMemoryType type, dynamic value) async {}
+}
+
+class FakeUrlLauncherPlatform extends UrlLauncherPlatform {
+  String? lastLaunchedUrl;
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async {
+    return true;
+  }
+
+  @override
+  Future<bool> launch(
+    String url, {
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
+  }) async {
+    lastLaunchedUrl = url;
+    return true;
+  }
+}
+
+Widget buildEmergencyDialogTestApp({
+  required EmergencyDialogBox dialog,
+  required UserInformation userInformation,
+  required AppInformation appInformation,
+}) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<UserInformation>.value(value: userInformation),
+      ChangeNotifierProvider<AppInformation>.value(value: appInformation),
+    ],
+    child: MaterialApp(
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      locale: const Locale('en'),
+      home: ScreenUtilInit(
+        designSize: const Size(360, 690),
+        child: dialog,
+      ),
+    ),
+  );
+}
+
+void main() {
+  test('Israel emergency numbers include correct Eran phone + WhatsApp', () {
+    final israel = countries['israel'];
+    expect(israel, isNotNull);
+
+    final eran = israel!.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'ער\"ן');
+
+    expect(eran['number'], '1201');
+    expect(eran['whatsapp'], true);
+    expect(eran['whatsappNumber'], '972528451201');
+  });
+
+  test('105 entry uses WhatsApp chat number 0521210105', () {
+    final israel = countries['israel'];
+    expect(israel, isNotNull);
+
+    final entry105 = israel!.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == '105');
+
+    expect(entry105['number'], '105');
+    expect(entry105['whatsapp'], true);
+    expect(entry105['whatsappNumber'], '0521210105');
+  });
+
+  test('Emergency numbers match reference data for AU/US/UK/EU', () {
+    final usa = countries['usa'];
+    final uk = countries['uk'];
+    final eu = countries['eu'];
+    final australia = countries['australia'];
+
+    expect(usa, isNotNull);
+    expect(uk, isNotNull);
+    expect(eu, isNotNull);
+    expect(australia, isNotNull);
+
+    final usaEmergency =
+        usa!.emergencyNumbers.firstWhere((entry) => entry['name'] == 'Emergency');
+    expect(usaEmergency['number'], '911');
+
+    final veterans = usa.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'Veterans Crisis Line');
+    expect(veterans['number'], '18002738255');
+
+    final trevor = usa.emergencyNumbers.firstWhere(
+        (entry) => entry['name'] == 'The Trevor Project (for LGBTQ+ youth)');
+    expect(trevor['number'], '18664887386');
+
+    final lifeline = usa.emergencyNumbers.firstWhere(
+        (entry) => entry['name'] == 'National Suicide Prevention Lifeline');
+    expect(lifeline['number'], '988');
+
+    final crisisTextLine = usa.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'Crisis Text Line');
+    expect(crisisTextLine['number'], '741741');
+
+    final ukEmergency =
+        uk!.emergencyNumbers.firstWhere((entry) => entry['name'] == 'Emergency');
+    expect(ukEmergency['number'], '999');
+
+    final samaritans =
+        uk.emergencyNumbers.firstWhere((entry) => entry['name'] == 'Samaritans');
+    expect(samaritans['number'], '116123');
+
+    final shout =
+        uk.emergencyNumbers.firstWhere((entry) => entry['name'] == 'Shout');
+    expect(shout['number'], '85258');
+
+    final calm = uk.emergencyNumbers.firstWhere((entry) =>
+        entry['name'] == 'CALM (Campaign Against Living Miserably, for men)');
+    expect(calm['number'], '0800585858');
+
+    final papyrus = uk.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'Papyrus (for people under 35)');
+    expect(papyrus['number'], '08000684141');
+
+    final euEmergency = eu!.emergencyNumbers.firstWhere(
+        (entry) => entry['name'] == 'European Emergency Number');
+    expect(euEmergency['number'], '112');
+
+    final mentalHealthEurope = eu.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'Mental Health Europe');
+    expect(mentalHealthEurope['link'], 'https://mhe-sme.org/');
+
+    final auEmergency = australia!.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'Emergency');
+    expect(auEmergency['number'], '000');
+
+    final lifelineAu = australia.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'Lifeline Australia');
+    expect(lifelineAu['number'], '131114');
+
+    final beyondBlue = australia.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'Beyond Blue');
+    expect(beyondBlue['number'], '1300224636');
+
+    final kidsHelpline = australia.emergencyNumbers.firstWhere(
+        (entry) => entry['name'] == 'Kids Helpline (for people aged 5-25)');
+    expect(kidsHelpline['number'], '1800551800');
+
+    final mensLine = australia.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'MensLine Australia');
+    expect(mensLine['number'], '1300789978');
+  });
+
+  testWidgets('EmergencyDialogBox uses whatsappNumber for WhatsApp action',
+      (tester) async {
+    final originalPlatform = UrlLauncherPlatform.instance;
+    final fakePlatform = FakeUrlLauncherPlatform();
+    UrlLauncherPlatform.instance = fakePlatform;
+    addTearDown(() {
+      UrlLauncherPlatform.instance = originalPlatform;
+    });
+
+    final userInfo = UserInformation(
+      gender: 'male',
+      service: FakePersistentMemoryService(),
+    );
+    final appInfo = AppInformation();
+
+    await tester.pumpWidget(
+      buildEmergencyDialogTestApp(
+        dialog: const EmergencyDialogBox(
+          number: '105',
+          whatsappNumber: '0521210105',
+          link: '',
+          hasWhatsApp: true,
+          hasLink: false,
+          canCall: false,
+        ),
+        userInformation: userInfo,
+        appInformation: appInfo,
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.chat));
+    await tester.pumpAndSettle();
+
+    expect(fakePlatform.lastLaunchedUrl, 'https://wa.me/0521210105');
+  });
+}


### PR DESCRIPTION
This PR fixes multiple SOS‑page issues and hardens the related widget tests.

# Fixes

ERAN (ער״ן): dial 1201 and WhatsApp opens +972 52 845 1201 (https://wa.me/972528451201).
105: WhatsApp chat now uses 0521210105 (dial still 105).
WhatsApp action uses a dedicated whatsappNumber when present.
Country selection now defaults to device locale when empty and shows flags in the selector.
SOS content is driven by the selected country (Israel/US/UK/EU/AU data verified).

# Test improvements

Added tests for WhatsApp numbers and country data.
Added test for country selector locale default.
Stabilized menu navigation widget tests with ensureVisible/pumpAndSettle.
Prevented share dialog overflow by allowing button text to expand.

# Files touched (high‑level)

EmergencyNumbers.dart
emergencyDialogBox.dart
EmergencyPhones.dart
CountrySelectorWidget.dart
LP_alert_dialog_box_item.dart
emergency_whatsapp_test.dart
country_selector_widget_test.dart
test/MenuTest/* (FeelGood, Wellness, Share tests)
syncing.md

# related issues
#210 , #212 , #198, #201, #218

# related pull requests:
#200 , #213, #214

# Tests
flutter test
emergency_whatsapp_test.dart
country_selector_widget_test.dart