### PR TITLE
Improve support tools navigation access

### DIFF
--- a/android/app/src/main/kotlin/com/example/mezilon/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mezilon/MainActivity.kt
@@ -1,40 +1,6 @@
 package com.example.mezilon
 
-import android.content.ActivityNotFoundException
-import android.content.Intent
-import android.net.Uri
 import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity() {
-    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        super.configureFlutterEngine(flutterEngine)
-
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, PHONE_CHANNEL)
-            .setMethodCallHandler { call, result ->
-                if (call.method != "dial") {
-                    result.notImplemented()
-                    return@setMethodCallHandler
-                }
-
-                val number = call.argument<String>("number")
-                if (number.isNullOrBlank()) {
-                    result.success(false)
-                    return@setMethodCallHandler
-                }
-
-                val intent = Intent(Intent.ACTION_DIAL, Uri.parse("tel:$number"))
-                try {
-                    startActivity(intent)
-                    result.success(true)
-                } catch (_: ActivityNotFoundException) {
-                    result.success(false)
-                }
-            }
-    }
-
-    companion object {
-        private const val PHONE_CHANNEL = "mazilon/phone"
-    }
+class MainActivity: FlutterActivity() {
 }

--- a/android/app/src/main/kotlin/com/example/mezilon/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mezilon/MainActivity.kt
@@ -1,6 +1,40 @@
 package com.example.mezilon
 
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterActivity() {
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, PHONE_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                if (call.method != "dial") {
+                    result.notImplemented()
+                    return@setMethodCallHandler
+                }
+
+                val number = call.argument<String>("number")
+                if (number.isNullOrBlank()) {
+                    result.success(false)
+                    return@setMethodCallHandler
+                }
+
+                val intent = Intent(Intent.ACTION_DIAL, Uri.parse("tel:$number"))
+                try {
+                    startActivity(intent)
+                    result.success(true)
+                } catch (_: ActivityNotFoundException) {
+                    result.success(false)
+                }
+            }
+    }
+
+    companion object {
+        private const val PHONE_CHANNEL = "mazilon/phone"
+    }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -310,10 +310,15 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 
   void changeLocale(String locale) {
     LocaleService localeService = GetIt.instance<LocaleService>();
+    PersistentMemoryService service = GetIt.instance<PersistentMemoryService>();
 
     setState(() {
       localeService.setLocale(locale);
+      localeName = localeService.getLocale();
     });
+    service.setItem("localeName", PersistentMemoryType.String, locale);
+    Provider.of<UserInformation>(context, listen: false)
+        .updateLocaleName(locale);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final currentContext = _navigatorKey.currentContext;
       if (currentContext == null) return;

--- a/lib/main_menu_dialog.dart
+++ b/lib/main_menu_dialog.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
+import 'package:mazilon/pages/UserSettings.dart';
+import 'package:mazilon/util/Form/formPagePhoneModel.dart';
+import 'package:mazilon/util/styles.dart';
+import 'package:mazilon/util/userInformation.dart';
+import 'package:share_plus/share_plus.dart';
+
+void showMainMenuDialog({
+  required BuildContext context,
+  required BuildContext anchorContext,
+  required AppLocalizations appLocale,
+  required UserInformation userInformation,
+  required PhonePageData phonePageData,
+  required Function changeLocale,
+  required bool isWeb,
+  required VoidCallback onAboutPressed,
+  required VoidCallback onNotificationsPressed,
+}) {
+  final gender = userInformation.gender;
+  final age = userInformation.age;
+  final mediaQuery = MediaQuery.of(context);
+  final screenWidth = mediaQuery.size.width;
+  final isRtl = appLocale.textDirection == "rtl";
+  final maxMenuWidth = screenWidth - 24 < 260 ? screenWidth - 24 : 260.0;
+  final minMenuWidth = maxMenuWidth < 180 ? maxMenuWidth : 180.0;
+  final menuWidth = (screenWidth * (isRtl ? 0.38 : 0.45))
+      .clamp(minMenuWidth, maxMenuWidth)
+      .toDouble();
+  final anchorBox = anchorContext.findRenderObject();
+  final overlayBox = Overlay.of(context).context.findRenderObject();
+  var menuLeft = isRtl ? 12.0 : screenWidth - menuWidth - 12.0;
+  var menuTop = mediaQuery.padding.top + kToolbarHeight;
+
+  if (anchorBox is RenderBox && overlayBox is RenderBox) {
+    final anchorOffset =
+        anchorBox.localToGlobal(Offset.zero, ancestor: overlayBox);
+
+    menuLeft = isRtl
+        ? anchorOffset.dx
+        : anchorOffset.dx + anchorBox.size.width - menuWidth;
+    menuTop = anchorOffset.dy + anchorBox.size.height + 8;
+  }
+
+  menuLeft = menuLeft.clamp(12.0, screenWidth - menuWidth - 12.0).toDouble();
+
+  showGeneralDialog(
+    context: context,
+    barrierDismissible: true,
+    barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    barrierColor: Colors.black45,
+    transitionDuration: const Duration(milliseconds: 200),
+    pageBuilder: (BuildContext buildContext, Animation<double> animation,
+        Animation<double> secondaryAnimation) {
+      return Stack(
+        children: [
+          Positioned(
+            left: menuLeft,
+            top: menuTop,
+            width: menuWidth,
+            child: Material(
+              key: const Key('mainMenuDialog'),
+              color: Colors.white,
+              elevation: 24.0,
+              shape: Border.all(
+                color: primaryPurple,
+                width: 2,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Row(
+                    textDirection:
+                        isRtl ? TextDirection.ltr : TextDirection.rtl,
+                    children: [
+                      IconButton(
+                        key: const Key('mainMenuCloseButton'),
+                        icon: const Icon(Icons.close),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                      ),
+                      Expanded(
+                        child: Align(
+                          alignment: isRtl
+                              ? Alignment.centerRight
+                              : Alignment.centerLeft,
+                          child: TextButton(
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Icon(Icons.people),
+                                const SizedBox(width: 20),
+                                Text(appLocale.homePageAbout(gender)),
+                              ],
+                            ),
+                            onPressed: () {
+                              onAboutPressed();
+                              Navigator.of(context).pop();
+                            },
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  _notificationButton(
+                    context: context,
+                    appLocale: appLocale,
+                    gender: gender,
+                    isWeb: isWeb,
+                    onNotificationsPressed: onNotificationsPressed,
+                  ),
+                  TextButton(
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        const Icon(Icons.settings),
+                        const SizedBox(width: 20),
+                        Text(appLocale.settings(gender)),
+                      ],
+                    ),
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) => UserSettings(
+                                  phonePageData: phonePageData,
+                                  username: userInformation.name,
+                                  age: age,
+                                  gender: gender,
+                                  changeLocale: changeLocale,
+                                )),
+                      );
+                    },
+                  ),
+                  TextButton(
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        const Icon(Icons.share),
+                        const SizedBox(width: 20),
+                        Text(appLocale.shareButtonText),
+                      ],
+                    ),
+                    onPressed: () async {
+                      await SharePlus.instance.share(
+                        ShareParams(
+                          text:
+                              '${appLocale.shareAppMessage}\n https://sites.google.com/mishol.org/matzilon/%D7%91%D7%99%D7%AA',
+                          subject: 'Living Positively App',
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      );
+    },
+  );
+}
+
+Widget _notificationButton({
+  required BuildContext context,
+  required AppLocalizations appLocale,
+  required String gender,
+  required bool isWeb,
+  required VoidCallback onNotificationsPressed,
+}) {
+  if (isWeb) {
+    return const SizedBox.shrink();
+  }
+
+  return TextButton(
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        const Icon(Icons.notification_add),
+        const SizedBox(width: 20),
+        Text(appLocale.notifications(gender)),
+      ],
+    ),
+    onPressed: () {
+      onNotificationsPressed();
+      Navigator.of(context).pop();
+    },
+  );
+}

--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mazilon/AnalyticsService.dart';
 import 'package:mazilon/global_enums.dart';
+import 'package:mazilon/main_menu_dialog.dart';
 import 'package:mazilon/pages/about.dart';
 import 'package:mazilon/pages/FeelGood/feelGood.dart';
 import 'package:mazilon/pages/WellnessTools/wellnessTools.dart';
@@ -13,7 +14,6 @@ import 'package:mazilon/util/Form/retrieveInformation.dart';
 import 'package:flutter/services.dart';
 import 'package:mazilon/util/LP_extended_state.dart';
 import 'package:mazilon/util/persistent_memory_service.dart';
-import 'package:mazilon/pages/UserSettings.dart';
 
 import 'package:mazilon/pages/home.dart';
 import 'package:mazilon/pages/journal.dart';
@@ -30,7 +30,6 @@ import 'package:mazilon/util/HomePage/bottomNavigationItem.dart';
 import 'package:mazilon/util/userInformation.dart';
 import 'package:provider/provider.dart';
 import 'package:mazilon/l10n/app_localizations.dart';
-import 'package:share_plus/share_plus.dart';
 
 class Menu extends StatefulWidget {
   final PhonePageData phonePageData;
@@ -141,31 +140,6 @@ class _MenuState extends LPExtendedState<Menu> {
     version = packageInfo.version;
   }
 
-  Widget displayNotificationButton(String gender, bool isWeb) {
-    if (isWeb) {
-      return const SizedBox.shrink();
-    }
-
-    return TextButton(
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: [
-          Icon(Icons.notification_add),
-          SizedBox(width: 20),
-          Text(AppLocalizations.of(context)!.notifications(gender)),
-        ],
-      ),
-      onPressed: () {
-        setState(() {
-          currentScreen = NotificationPage();
-
-          current = PagesCode.NotificationPage;
-        });
-        Navigator.of(context).pop();
-      },
-    );
-  }
-
   Map<String, List<String>> _filterVideoByLocal(
       Map<String, List<String>> videos) {
     var localizedVideos = {
@@ -215,145 +189,25 @@ class _MenuState extends LPExtendedState<Menu> {
   void _showMainMenu(BuildContext anchorContext) {
     final userInformation =
         Provider.of<UserInformation>(context, listen: false);
-    final gender = userInformation.gender;
-    final age = userInformation.age;
-    final mediaQuery = MediaQuery.of(context);
-    final screenWidth = mediaQuery.size.width;
-    final isRtl = appLocale.textDirection == "rtl";
-    final maxMenuWidth = screenWidth - 24 < 260 ? screenWidth - 24 : 260.0;
-    final minMenuWidth = maxMenuWidth < 180 ? maxMenuWidth : 180.0;
-    final menuWidth = (screenWidth * (isRtl ? 0.38 : 0.45))
-        .clamp(minMenuWidth, maxMenuWidth)
-        .toDouble();
-    final anchorBox = anchorContext.findRenderObject();
-    final overlayBox = Overlay.of(context).context.findRenderObject();
-    var menuLeft = isRtl ? 12.0 : screenWidth - menuWidth - 12.0;
-    var menuTop = mediaQuery.padding.top + kToolbarHeight;
-
-    if (anchorBox is RenderBox && overlayBox is RenderBox) {
-      final anchorOffset =
-          anchorBox.localToGlobal(Offset.zero, ancestor: overlayBox);
-
-      menuLeft = isRtl
-          ? anchorOffset.dx
-          : anchorOffset.dx + anchorBox.size.width - menuWidth;
-      menuTop = anchorOffset.dy + anchorBox.size.height + 8;
-    }
-
-    menuLeft = menuLeft.clamp(12.0, screenWidth - menuWidth - 12.0);
-
-    showGeneralDialog(
+    showMainMenuDialog(
       context: context,
-      barrierDismissible: true,
-      barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-      barrierColor: Colors.black45,
-      transitionDuration: const Duration(milliseconds: 200),
-      pageBuilder: (BuildContext buildContext, Animation animation,
-          Animation secondaryAnimation) {
-        return Stack(
-          children: [
-            Positioned(
-              left: menuLeft,
-              top: menuTop,
-              width: menuWidth,
-              child: Material(
-                key: const Key('mainMenuDialog'),
-                color: Colors.white,
-                elevation: 24.0,
-                shape: Border.all(
-                  color: primaryPurple,
-                  width: 2,
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    Row(
-                      textDirection:
-                          isRtl ? TextDirection.ltr : TextDirection.rtl,
-                      children: [
-                        IconButton(
-                          key: const Key('mainMenuCloseButton'),
-                          icon: Icon(Icons.close),
-                          onPressed: () {
-                            Navigator.of(context).pop();
-                          },
-                        ),
-                        Expanded(
-                          child: Align(
-                            alignment: isRtl
-                                ? Alignment.centerRight
-                                : Alignment.centerLeft,
-                            child: TextButton(
-                              child: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Icon(Icons.people),
-                                  SizedBox(width: 20),
-                                  Text(appLocale.homePageAbout(gender)),
-                                ],
-                              ),
-                              onPressed: () {
-                                setState(() {
-                                  currentScreen = About(version: version);
-                                  current = PagesCode.About;
-                                });
-                                Navigator.of(context).pop();
-                              },
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                    displayNotificationButton(gender, kIsWeb),
-                    TextButton(
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: [
-                          Icon(Icons.settings),
-                          SizedBox(width: 20),
-                          Text(appLocale.settings(gender)),
-                        ],
-                      ),
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => UserSettings(
-                                    phonePageData: widget.phonePageData,
-                                    username: userInformation.name,
-                                    age: age,
-                                    gender: gender,
-                                    changeLocale: widget.changeLocale,
-                                  )),
-                        );
-                      },
-                    ),
-                    TextButton(
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: [
-                          Icon(Icons.share),
-                          SizedBox(width: 20),
-                          Text(appLocale.shareButtonText),
-                        ],
-                      ),
-                      onPressed: () async {
-                        await SharePlus.instance.share(
-                          ShareParams(
-                            text:
-                                '${appLocale.shareAppMessage}\n https://sites.google.com/mishol.org/matzilon/%D7%91%D7%99%D7%AA',
-                            subject: 'Living Positively App',
-                          ),
-                        );
-                      },
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ],
-        );
+      anchorContext: anchorContext,
+      appLocale: appLocale,
+      userInformation: userInformation,
+      phonePageData: widget.phonePageData,
+      changeLocale: widget.changeLocale,
+      isWeb: kIsWeb,
+      onAboutPressed: () {
+        setState(() {
+          currentScreen = About(version: version);
+          current = PagesCode.About;
+        });
+      },
+      onNotificationsPressed: () {
+        setState(() {
+          currentScreen = NotificationPage();
+          current = PagesCode.NotificationPage;
+        });
       },
     );
   }

--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -21,7 +21,6 @@ import 'package:mazilon/pages/phone.dart';
 import 'package:mazilon/pages/positive.dart';
 import 'package:mazilon/pages/PersonalPlan/myPlanPageFull.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:mazilon/pages/UserSettings.dart';
 
 import 'package:mazilon/util/appInformation.dart';
 import 'package:mazilon/util/styles.dart';
@@ -142,9 +141,9 @@ class _MenuState extends LPExtendedState<Menu> {
     version = packageInfo.version;
   }
 
-  Widget displayNotificationButton(gender, kIsWeb) {
-    if (kIsWeb) {
-      return SizedBox.shrink();
+  Widget displayNotificationButton(String gender, bool isWeb) {
+    if (isWeb) {
+      return const SizedBox.shrink();
     }
 
     return TextButton(
@@ -177,7 +176,7 @@ class _MenuState extends LPExtendedState<Menu> {
     };
 
     for (var i = 0; i < videos["videoLocale"]!.length; i++) {
-      var video = videos["videoLocale"]![i] ?? "he";
+      var video = videos["videoLocale"]![i];
       if (video == Localizations.localeOf(context).languageCode) {
         /*    'videoId': [],
     'videoHeadline': [],
@@ -187,11 +186,164 @@ class _MenuState extends LPExtendedState<Menu> {
         localizedVideos['videoHeadline']?.add(videos["videoHeadline"]![i]);
         localizedVideos['videoDescription']
             ?.add(videos["videoDescription"]![i]);
-        localizedVideos['videoLocal']?.add(videos["videoLocal"]![i]);
+        localizedVideos['videoLocale']?.add(videos["videoLocale"]![i]);
       }
     }
 
     return localizedVideos;
+  }
+
+  Widget _buildHomeScreen() {
+    return Home(
+      phonePageData: widget.phonePageData,
+      changeCurrentIndex: changeCurrentIndex,
+      changeLocale: widget.changeLocale,
+      openMainMenu: _showMainMenu,
+    );
+  }
+
+  void _showWellnessTools(AppInformation appInfoProvider) {
+    setState(() {
+      currentScreen = WellnessTools(
+          isFullScreen: isFullScreen,
+          videoData: _filterVideoByLocal(appInfoProvider.wellnessVideos),
+          setBool: setFullScreen);
+      current = PagesCode.WellnessToolsPage;
+    });
+  }
+
+  void _showMainMenu(BuildContext anchorContext) {
+    final userInformation =
+        Provider.of<UserInformation>(context, listen: false);
+    final gender = userInformation.gender;
+    final age = userInformation.age;
+    final mediaQuery = MediaQuery.of(context);
+    final screenWidth = mediaQuery.size.width;
+    final menuWidth = screenWidth * 0.5;
+    final anchorBox = anchorContext.findRenderObject();
+    final overlayBox = Overlay.of(context).context.findRenderObject();
+    var menuLeft = appLocale.textDirection == "rtl"
+        ? 12.0
+        : screenWidth - menuWidth - 12.0;
+    var menuTop = mediaQuery.padding.top + kToolbarHeight;
+
+    if (anchorBox is RenderBox && overlayBox is RenderBox) {
+      final anchorOffset =
+          anchorBox.localToGlobal(Offset.zero, ancestor: overlayBox);
+
+      menuLeft = appLocale.textDirection == "rtl"
+          ? anchorOffset.dx
+          : anchorOffset.dx + anchorBox.size.width - menuWidth;
+      menuTop = anchorOffset.dy + anchorBox.size.height + 8;
+    }
+
+    menuLeft = menuLeft.clamp(12.0, screenWidth - menuWidth - 12.0);
+
+    showGeneralDialog(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+      barrierColor: Colors.black45,
+      transitionDuration: const Duration(milliseconds: 200),
+      pageBuilder: (BuildContext buildContext, Animation animation,
+          Animation secondaryAnimation) {
+        return Stack(
+          children: [
+            Positioned(
+              left: menuLeft,
+              top: menuTop,
+              width: menuWidth,
+              child: Material(
+                key: const Key('mainMenuDialog'),
+                color: Colors.white,
+                elevation: 24.0,
+                shape: Border.all(
+                  color: primaryPurple,
+                  width: 2,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Align(
+                      alignment: appLocale.textDirection == "rtl"
+                          ? Alignment.topRight
+                          : Alignment.topLeft,
+                      child: IconButton(
+                        icon: Icon(Icons.close),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                      ),
+                    ),
+                    TextButton(
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Icon(Icons.people),
+                          SizedBox(width: 20),
+                          Text(appLocale.homePageAbout(gender)),
+                        ],
+                      ),
+                      onPressed: () {
+                        setState(() {
+                          currentScreen = About(version: version);
+                          current = PagesCode.About;
+                        });
+                        Navigator.of(context).pop();
+                      },
+                    ),
+                    displayNotificationButton(gender, kIsWeb),
+                    TextButton(
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Icon(Icons.settings),
+                          SizedBox(width: 20),
+                          Text(appLocale.settings(gender)),
+                        ],
+                      ),
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => UserSettings(
+                                    phonePageData: widget.phonePageData,
+                                    username: userInformation.name,
+                                    age: age,
+                                    gender: gender,
+                                    changeLocale: widget.changeLocale,
+                                  )),
+                        );
+                      },
+                    ),
+                    TextButton(
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Icon(Icons.share),
+                          SizedBox(width: 20),
+                          Text(appLocale.shareButtonText),
+                        ],
+                      ),
+                      onPressed: () async {
+                        await SharePlus.instance.share(
+                          ShareParams(
+                            text:
+                                '${appLocale.shareAppMessage}\n https://sites.google.com/mishol.org/matzilon/%D7%91%D7%99%D7%AA',
+                            subject: 'Living Positively App',
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
@@ -200,11 +352,7 @@ class _MenuState extends LPExtendedState<Menu> {
     getVersion();
     super.initState();
     //this is the initial page
-    currentScreen = Home(
-      phonePageData: widget.phonePageData,
-      changeCurrentIndex: changeCurrentIndex,
-      changeLocale: widget.changeLocale,
-    );
+    currentScreen = _buildHomeScreen();
   }
 
   @override
@@ -213,7 +361,6 @@ class _MenuState extends LPExtendedState<Menu> {
     final userInformation = Provider.of<UserInformation>(context);
     final appInfoProvider = Provider.of<AppInformation>(context);
     final gender = userInformation.gender;
-    final age = userInformation.age;
     testingChange();
 
     return PopScope(
@@ -227,11 +374,7 @@ class _MenuState extends LPExtendedState<Menu> {
             SystemChannels.platform.invokeMethod('SystemNavigator.pop');
           }
           changeCurrentIndex(context, PagesCode.Home);
-          currentScreen = Home(
-            phonePageData: widget.phonePageData,
-            changeCurrentIndex: changeCurrentIndex,
-            changeLocale: widget.changeLocale,
-          );
+          currentScreen = _buildHomeScreen();
         }
       },
       child: Scaffold(
@@ -280,267 +423,107 @@ class _MenuState extends LPExtendedState<Menu> {
                 child: Container(
                   color: appWhite,
                   height: 60,
-                  child: Row(
-                    // mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Container(
-                        width: appLocale.localeName == 'en'
-                            ? MediaQuery.of(context).size.width / 6
-                            : MediaQuery.of(context).size.width / 8,
-                        alignment: appLocale.textDirection == "rtl"
-                            ? Alignment.centerLeft
-                            : Alignment.centerRight,
-                        child: TextButton(
-                            onPressed: () {
-                              setState(() {
-                                currentScreen = Home(
-                                  phonePageData: widget.phonePageData,
-                                  changeCurrentIndex: changeCurrentIndex,
-                                  changeLocale: widget.changeLocale,
-                                );
-                                current = PagesCode.Home;
-                              });
-                            },
-                            child: bottomNavigationItem(current == 0,
-                                Icons.home, appLocale.home(gender))),
-                      ),
-                      Container(
-                        alignment: appLocale.textDirection == "rtl"
-                            ? Alignment.centerLeft
-                            : Alignment.centerRight,
-                        width: appLocale.localeName == 'en'
-                            ? MediaQuery.of(context).size.width / 5
-                            : MediaQuery.of(context).size.width / 4,
-                        child: TextButton(
-                            onPressed: () {
-                              setState(() {
-                                currentScreen = MyPlanPageFull(
-                                  phonePageData: widget.phonePageData,
-                                  hasFilled: widget.hasFilled,
-                                  changeLocale: widget.changeLocale,
-                                );
-                                current = PagesCode.FullPlan;
-                              });
-                            },
-                            child: bottomNavigationItem(
-                                current == PagesCode.FullPlan,
-                                Icons.assignment,
-                                appLocale.personalPlanPageMyPlan(gender))),
-                      ),
-                      Container(
-                        width: MediaQuery.of(context).size.width / 9,
-                      ),
-                      Container(
-                        alignment: appLocale.textDirection == "rtl"
-                            ? Alignment.centerLeft
-                            : Alignment.centerRight,
-                        width: MediaQuery.of(context).size.width / 4,
-                        child: TextButton(
-                            onPressed: () {
-                              setState(() {
-                                mixPanelService.trackEvent(
-                                  "Viewed Feel Good Page",
-                                );
-                                currentScreen = FeelGood();
-                                current = PagesCode.FeelGoodPage;
-                              });
-                            },
-                            child: bottomNavigationItem(
-                                current == PagesCode.FeelGoodPage,
-                                Icons.emoji_emotions_outlined,
-                                AppLocalizations.of(context)!
-                                    .homePageFeelGood(gender))),
-                      ),
-                      Container(
-                        width: MediaQuery.of(context).size.width / 5.5,
-                        child: Align(
-                          alignment: appLocale.textDirection == "rtl"
-                              ? Alignment.centerLeft
-                              : Alignment.centerRight,
-                          child: TextButton(
-                            onPressed: () {
-                              showGeneralDialog(
-                                context: context,
-                                barrierDismissible: true,
-                                barrierLabel: MaterialLocalizations.of(context)
-                                    .modalBarrierDismissLabel,
-                                barrierColor: Colors.black45,
-                                transitionDuration:
-                                    const Duration(milliseconds: 200),
-                                pageBuilder: (BuildContext buildContext,
-                                    Animation animation,
-                                    Animation secondaryAnimation) {
-                                  return FractionallySizedBox(
-                                    heightFactor: 0.85,
-                                    widthFactor: 0.6,
-                                    alignment: appLocale!.textDirection == "rtl"
-                                        ? Alignment.centerLeft
-                                        : Alignment.centerRight,
-                                    child: Align(
-                                      alignment: Alignment
-                                          .bottomCenter, // Change alignment to bottom center
-                                      child: Padding(
-                                        padding: const EdgeInsets.all(12.0),
-                                        child: Material(
-                                          color: Colors.white,
-                                          elevation: 24.0,
-                                          shape: Border.all(
-                                            color: primaryPurple,
-                                            width: 2,
-                                          ),
-                                          child: Container(
-                                            width: MediaQuery.of(context)
-                                                    .size
-                                                    .width *
-                                                0.5,
-                                            child: Column(
-                                              mainAxisSize: MainAxisSize.min,
-                                              children: <Widget>[
-                                                Align(
-                                                  alignment: AppLocalizations
-                                                                  .of(context)!
-                                                              .textDirection ==
-                                                          "rtl"
-                                                      ? Alignment.topRight
-                                                      : Alignment.topLeft,
-                                                  child: IconButton(
-                                                    icon: Icon(Icons.close),
-                                                    onPressed: () {
-                                                      Navigator.of(context)
-                                                          .pop();
-                                                    },
-                                                  ),
-                                                ),
-                                                TextButton(
-                                                  child: Row(
-                                                    mainAxisAlignment:
-                                                        MainAxisAlignment.start,
-                                                    children: [
-                                                      Icon(Icons.people),
-                                                      SizedBox(width: 20),
-                                                      Text(AppLocalizations.of(
-                                                              context)!
-                                                          .homePageAbout(
-                                                              gender)),
-                                                    ],
-                                                  ),
-                                                  onPressed: () {
-                                                    setState(() {
-                                                      currentScreen = About(
-                                                          version: version);
-                                                      current = PagesCode.About;
-                                                    });
-                                                    Navigator.of(context).pop();
-                                                  },
-                                                ),
-                                                displayNotificationButton(
-                                                    gender, kIsWeb),
-                                                TextButton(
-                                                  child: Row(
-                                                    mainAxisAlignment:
-                                                        MainAxisAlignment.start,
-                                                    children: [
-                                                      Icon(Icons.settings),
-                                                      SizedBox(width: 20),
-                                                      Text(AppLocalizations.of(
-                                                              context)!
-                                                          .settings(gender)),
-                                                    ],
-                                                  ),
-                                                  onPressed: () {
-                                                    Navigator.of(context).pop();
-                                                    Navigator.push(
-                                                      context,
-                                                      MaterialPageRoute(
-                                                          builder: (context) =>
-                                                              UserSettings(
-                                                                phonePageData:
-                                                                    widget
-                                                                        .phonePageData,
-                                                                username:
-                                                                    userInformation
-                                                                        .name,
-                                                                age: age,
-                                                                gender: gender,
-                                                                changeLocale: widget
-                                                                    .changeLocale,
-                                                              )),
-                                                    );
-                                                  },
-                                                ),
-                                                TextButton(
-                                                  child: Row(
-                                                    mainAxisAlignment:
-                                                        MainAxisAlignment.start,
-                                                    children: [
-                                                      Icon(Icons.yard_outlined),
-                                                      SizedBox(width: 20),
-                                                      Text(AppLocalizations.of(
-                                                              context)!
-                                                          .homePageWellnessTools(
-                                                              gender)),
-                                                    ],
-                                                  ),
-                                                  onPressed: () {
-                                                    setState(() {
-                                                      currentScreen = WellnessTools(
-                                                          isFullScreen:
-                                                              isFullScreen,
-                                                          videoData:
-                                                              _filterVideoByLocal(
-                                                                  appInfoProvider
-                                                                      .wellnessVideos),
-                                                          setBool:
-                                                              setFullScreen);
-                                                      current = PagesCode
-                                                          .WellnessToolsPage;
-                                                    });
-                                                    Navigator.of(context).pop();
-                                                  },
-                                                ),
-                                                TextButton(
-                                                  child: Row(
-                                                    mainAxisAlignment:
-                                                        MainAxisAlignment.start,
-                                                    children: [
-                                                      Icon(Icons.share),
-                                                      SizedBox(width: 20),
-                                                      Text(appLocale
-                                                          .shareButtonText),
-                                                    ],
-                                                  ),
-                                                  onPressed: () async {
-                                                    // Share app text with others
-                                                    await Share.share(
-                                                      '${appLocale.shareAppMessage}\n https://sites.google.com/mishol.org/matzilon/%D7%91%D7%99%D7%AA',
-                                                      subject:
-                                                          'Living Positively App',
-                                                    );
-                                                  },
-                                                ),
-                                              ],
-                                            ),
-                                          ),
-                                        ),
-                                      ),
-                                    ),
-                                  );
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      final navWidth = constraints.maxWidth;
+
+                      return Row(
+                        // mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Container(
+                            width: appLocale.localeName == 'en'
+                                ? navWidth / 6
+                                : navWidth / 8,
+                            alignment: appLocale.textDirection == "rtl"
+                                ? Alignment.centerLeft
+                                : Alignment.centerRight,
+                            child: TextButton(
+                                onPressed: () {
+                                  setState(() {
+                                    currentScreen = _buildHomeScreen();
+                                    current = PagesCode.Home;
+                                  });
                                 },
-                              );
-                              setState(() {
-                                current = PagesCode.WellnessToolsPage;
-                              });
-                            },
-                            child: bottomNavigationItem(
-                                current == PagesCode.WellnessToolsPage ||
-                                    current == PagesCode.About ||
-                                    current == PagesCode.NotificationPage,
-                                Icons.menu,
-                                appLocale!.menu(gender)),
+                                child: bottomNavigationItem(
+                                    current == PagesCode.Home,
+                                    Icons.home,
+                                    appLocale.home(gender))),
                           ),
-                        ),
-                      ),
-                    ],
+                          Container(
+                            alignment: appLocale.textDirection == "rtl"
+                                ? Alignment.centerLeft
+                                : Alignment.centerRight,
+                            width: appLocale.localeName == 'en'
+                                ? navWidth / 5
+                                : navWidth / 4,
+                            child: TextButton(
+                                onPressed: () {
+                                  setState(() {
+                                    currentScreen = MyPlanPageFull(
+                                      phonePageData: widget.phonePageData,
+                                      hasFilled: widget.hasFilled,
+                                      changeLocale: widget.changeLocale,
+                                    );
+                                    current = PagesCode.FullPlan;
+                                  });
+                                },
+                                child: bottomNavigationItem(
+                                    current == PagesCode.FullPlan,
+                                    Icons.assignment,
+                                    appLocale.personalPlanPageMyPlan(gender))),
+                          ),
+                          SizedBox(
+                            width: navWidth / 9,
+                          ),
+                          Container(
+                            alignment: appLocale.textDirection == "rtl"
+                                ? Alignment.centerLeft
+                                : Alignment.centerRight,
+                            width: navWidth / 4,
+                            child: TextButton(
+                                onPressed: () {
+                                  setState(() {
+                                    mixPanelService.trackEvent(
+                                      "Viewed Feel Good Page",
+                                    );
+                                    currentScreen = FeelGood();
+                                    current = PagesCode.FeelGoodPage;
+                                  });
+                                },
+                                child: bottomNavigationItem(
+                                    current == PagesCode.FeelGoodPage,
+                                    Icons.emoji_emotions_outlined,
+                                    AppLocalizations.of(context)!
+                                        .homePageFeelGood(gender))),
+                          ),
+                          SizedBox(
+                            width: appLocale.localeName == 'en'
+                                ? navWidth / 4
+                                : navWidth / 4.5,
+                            child: Align(
+                              alignment: appLocale.textDirection == "rtl"
+                                  ? Alignment.centerLeft
+                                  : Alignment.centerRight,
+                              child: TextButton(
+                                style: TextButton.styleFrom(
+                                  padding: EdgeInsets.zero,
+                                  minimumSize: Size.zero,
+                                  tapTargetSize:
+                                      MaterialTapTargetSize.shrinkWrap,
+                                ),
+                                onPressed: () {
+                                  _showWellnessTools(appInfoProvider);
+                                },
+                                child: bottomNavigationItem(
+                                    current == PagesCode.WellnessToolsPage,
+                                    Icons.local_florist_outlined,
+                                    appLocale.homePageWellnessTools(gender)),
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    },
                   ),
                 ),
               ),

--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -219,19 +219,22 @@ class _MenuState extends LPExtendedState<Menu> {
     final age = userInformation.age;
     final mediaQuery = MediaQuery.of(context);
     final screenWidth = mediaQuery.size.width;
-    final menuWidth = screenWidth * 0.5;
+    final isRtl = appLocale.textDirection == "rtl";
+    final maxMenuWidth = screenWidth - 24 < 260 ? screenWidth - 24 : 260.0;
+    final minMenuWidth = maxMenuWidth < 180 ? maxMenuWidth : 180.0;
+    final menuWidth = (screenWidth * (isRtl ? 0.38 : 0.45))
+        .clamp(minMenuWidth, maxMenuWidth)
+        .toDouble();
     final anchorBox = anchorContext.findRenderObject();
     final overlayBox = Overlay.of(context).context.findRenderObject();
-    var menuLeft = appLocale.textDirection == "rtl"
-        ? 12.0
-        : screenWidth - menuWidth - 12.0;
+    var menuLeft = isRtl ? 12.0 : screenWidth - menuWidth - 12.0;
     var menuTop = mediaQuery.padding.top + kToolbarHeight;
 
     if (anchorBox is RenderBox && overlayBox is RenderBox) {
       final anchorOffset =
           anchorBox.localToGlobal(Offset.zero, ancestor: overlayBox);
 
-      menuLeft = appLocale.textDirection == "rtl"
+      menuLeft = isRtl
           ? anchorOffset.dx
           : anchorOffset.dx + anchorBox.size.width - menuWidth;
       menuTop = anchorOffset.dy + anchorBox.size.height + 8;
@@ -264,33 +267,42 @@ class _MenuState extends LPExtendedState<Menu> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: <Widget>[
-                    Align(
-                      alignment: appLocale.textDirection == "rtl"
-                          ? Alignment.topRight
-                          : Alignment.topLeft,
-                      child: IconButton(
-                        icon: Icon(Icons.close),
-                        onPressed: () {
-                          Navigator.of(context).pop();
-                        },
-                      ),
-                    ),
-                    TextButton(
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: [
-                          Icon(Icons.people),
-                          SizedBox(width: 20),
-                          Text(appLocale.homePageAbout(gender)),
-                        ],
-                      ),
-                      onPressed: () {
-                        setState(() {
-                          currentScreen = About(version: version);
-                          current = PagesCode.About;
-                        });
-                        Navigator.of(context).pop();
-                      },
+                    Row(
+                      textDirection:
+                          isRtl ? TextDirection.ltr : TextDirection.rtl,
+                      children: [
+                        IconButton(
+                          key: const Key('mainMenuCloseButton'),
+                          icon: Icon(Icons.close),
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                          },
+                        ),
+                        Expanded(
+                          child: Align(
+                            alignment: isRtl
+                                ? Alignment.centerRight
+                                : Alignment.centerLeft,
+                            child: TextButton(
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(Icons.people),
+                                  SizedBox(width: 20),
+                                  Text(appLocale.homePageAbout(gender)),
+                                ],
+                              ),
+                              onPressed: () {
+                                setState(() {
+                                  currentScreen = About(version: version);
+                                  current = PagesCode.About;
+                                });
+                                Navigator.of(context).pop();
+                              },
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                     displayNotificationButton(gender, kIsWeb),
                     TextButton(

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mazilon/MainPageHelpers/MainPageList/mainpage_list_widget.dart';
 import 'package:mazilon/global_enums.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
 
 import 'package:mazilon/util/Form/retrieveInformation.dart';
 import 'package:mazilon/util/LP_extended_state.dart';
@@ -30,15 +31,17 @@ import 'package:provider/provider.dart';
 //the main page of the app
 //allows navigation to all other pages
 class Home extends StatefulWidget {
-  PhonePageData phonePageData;
+  final PhonePageData phonePageData;
   final Function(BuildContext, PagesCode) changeCurrentIndex;
   final Function changeLocale;
+  final void Function(BuildContext) openMainMenu;
 
-  Home({
+  const Home({
     super.key,
     required this.phonePageData,
     required this.changeCurrentIndex,
     required this.changeLocale,
+    required this.openMainMenu,
   });
 
   @override
@@ -76,7 +79,8 @@ class _HomeState extends LPExtendedState<Home> {
 //fuction to handle the removal of a thank you
 
 //this selects what information to show in the personal plan widget boxes
-  void setRandomPersonalWidgetText(userInfo, appLocale) {
+  void setRandomPersonalWidgetText(
+      UserInformation userInfo, AppLocalizations appLocale) {
     var random = Random();
     var randomHeader = random.nextInt(4);
 
@@ -140,9 +144,9 @@ class _HomeState extends LPExtendedState<Home> {
         child: SingleChildScrollView(
           child: Column(
             children: [
-              //This shows the "hello <username>" banner and settings button
+              //This shows the "hello <username>" banner and header buttons
               NameBar(
-                  greetingString: appLocale!.homePageGreetings(gender),
+                  greetingString: appLocale.homePageGreetings(gender),
                   icons: [
                     //settings button:
                     myTextButton(() {
@@ -157,7 +161,13 @@ class _HomeState extends LPExtendedState<Home> {
                                   changeLocale: widget.changeLocale,
                                 )),
                       );
-                    }, Icons.settings_outlined, primaryPurple)
+                    }, Icons.settings_outlined, primaryPurple),
+                    Builder(
+                      builder: (menuButtonContext) => myTextButton(
+                          () => widget.openMainMenu(menuButtonContext),
+                          Icons.menu,
+                          primaryPurple),
+                    )
                   ]),
 
               Padding(

--- a/lib/util/Firebase/firebase_functions.dart
+++ b/lib/util/Firebase/firebase_functions.dart
@@ -136,14 +136,15 @@ Future<void> loadUserInformation(
   userInfo.updateDisclaimerSigned(data['disclaimerConfirmed'] ?? false);
   userInfo.updateNotificationMinute(data['notificationMinute'] ?? 0);
   userInfo.updateNotificationHour(data['notificationHour'] ?? 12);
-  userInfo.updateLocaleName(data['localeName'] ?? "en");
+  final savedLocale = data['localeName'];
+  userInfo.updateLocaleName(
+      savedLocale is String && savedLocale.isNotEmpty ? savedLocale : locale);
   userInfo.updatePositiveTraits(
       (TypeUtils.castToStringList(data['positiveTraits'])));
   userInfo.updateThanks({
     "thanks": (TypeUtils.castToStringList(data['thankYous'])),
     "dates": (TypeUtils.castToStringList(data['dates']))
   });
-  userInfo.updateLocaleName(locale);
 }
 
 //upon adding CMS(rowy) texts, this will need to be updated:

--- a/lib/util/HomePage/bottomNavigationItem.dart
+++ b/lib/util/HomePage/bottomNavigationItem.dart
@@ -4,7 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mazilon/util/styles.dart';
 
 //Item for the bottom Navigation in the home page
-Widget bottomNavigationItem(current, icon, text) {
+Widget bottomNavigationItem(bool current, IconData icon, String text) {
   Color color = current ? primaryPurple : darkGray;
   return Column(
     mainAxisAlignment: MainAxisAlignment.center,
@@ -16,12 +16,16 @@ Widget bottomNavigationItem(current, icon, text) {
         ),
       ),
       Expanded(
-        child: myAutoSizedText(
-            text,
-            TextStyle(
-                fontWeight: FontWeight.bold, color: color, fontSize: 14.sp),
-            null,
-            25),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 2),
+          child: myAutoSizedText(
+              text,
+              TextStyle(
+                  fontWeight: FontWeight.bold, color: color, fontSize: 14.sp),
+              null,
+              25,
+              1),
+        ),
       )
     ],
   );

--- a/lib/util/Phone/phoneTextAndIcon.dart
+++ b/lib/util/Phone/phoneTextAndIcon.dart
@@ -1,14 +1,11 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mazilon/util/styles.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 
-const MethodChannel _androidPhoneChannel = MethodChannel('mazilon/phone');
-
-Widget phoneContact(phone, contact) {
+Widget phoneContact(String phone, String contact) {
   return Row(
     children: <Widget>[
       InkWell(
@@ -40,32 +37,19 @@ Widget phoneContact(phone, contact) {
 }
 
 Future<void> dialPhone(String number) async {
-  final phoneNumber = _phoneNumberForTelUri(number);
-  if (defaultTargetPlatform == TargetPlatform.android) {
-    final launched = await _androidPhoneChannel.invokeMethod<bool>(
-      'dial',
-      <String, String>{'number': phoneNumber},
-    );
-    if (launched != true) {
-      debugPrint('Could not launch tel:$phoneNumber');
-    }
-    return;
-  }
-
-  final url = 'tel:$phoneNumber';
-  if (!await launchUrlString(url)) {
-    debugPrint('Could not launch $url');
+  final uri = _dialPhoneUri(number);
+  if (!await launchUrl(uri)) {
+    debugPrint('Could not launch $uri');
   }
 }
 
-String _phoneNumberForTelUri(String number) {
+Uri _dialPhoneUri(String number) {
   final trimmedNumber = number.trim();
   if (defaultTargetPlatform == TargetPlatform.android &&
       RegExp(r'^\d{4}$').hasMatch(trimmedNumber)) {
-    // Prevent Google Dialer from rendering 1201 as US-style "1 (201".
-    return '$trimmedNumber\u2060';
+    return Uri.parse('tel:${Uri.encodeComponent('$trimmedNumber ')}');
   }
-  return trimmedNumber;
+  return Uri.parse('tel:$trimmedNumber');
 }
 
 Future<void> openWhatsApp(String number) async {

--- a/lib/util/Phone/phoneTextAndIcon.dart
+++ b/lib/util/Phone/phoneTextAndIcon.dart
@@ -1,7 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mazilon/util/styles.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+const MethodChannel _androidPhoneChannel = MethodChannel('mazilon/phone');
 
 Widget phoneContact(phone, contact) {
   return Row(
@@ -35,10 +40,32 @@ Widget phoneContact(phone, contact) {
 }
 
 Future<void> dialPhone(String number) async {
-  final uri = Uri.parse('tel:$number');
-  if (!await launchUrl(uri)) {
-    debugPrint('Could not launch $uri');
+  final phoneNumber = _phoneNumberForTelUri(number);
+  if (defaultTargetPlatform == TargetPlatform.android) {
+    final launched = await _androidPhoneChannel.invokeMethod<bool>(
+      'dial',
+      <String, String>{'number': phoneNumber},
+    );
+    if (launched != true) {
+      debugPrint('Could not launch tel:$phoneNumber');
+    }
+    return;
   }
+
+  final url = 'tel:$phoneNumber';
+  if (!await launchUrlString(url)) {
+    debugPrint('Could not launch $url');
+  }
+}
+
+String _phoneNumberForTelUri(String number) {
+  final trimmedNumber = number.trim();
+  if (defaultTargetPlatform == TargetPlatform.android &&
+      RegExp(r'^\d{4}$').hasMatch(trimmedNumber)) {
+    // Prevent Google Dialer from rendering 1201 as US-style "1 (201".
+    return '$trimmedNumber\u2060';
+  }
+  return trimmedNumber;
 }
 
 Future<void> openWhatsApp(String number) async {

--- a/test/MenuTest/TestMenu.dart
+++ b/test/MenuTest/TestMenu.dart
@@ -8,7 +8,8 @@ import 'package:provider/provider.dart';
 import 'package:mazilon/l10n/app_localizations.dart';
 
 Widget getMenuForTests(
-    UserInformation mockUserInformation, AppInformation mockAppInformation) {
+    UserInformation mockUserInformation, AppInformation mockAppInformation,
+    {Locale locale = const Locale('he')}) {
   return MultiProvider(
     providers: [
       ChangeNotifierProvider<UserInformation>.value(value: mockUserInformation),
@@ -16,7 +17,7 @@ Widget getMenuForTests(
     ],
     child: MaterialApp(
       supportedLocales: AppLocalizations.supportedLocales,
-      locale: Locale('he'),
+      locale: locale,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       home: ScreenUtilInit(
         designSize: const Size(360, 690),

--- a/test/MenuTest/Wellness/wellnessTools_test.dart
+++ b/test/MenuTest/Wellness/wellnessTools_test.dart
@@ -119,10 +119,49 @@ void main() {
       await tapAndSettle(tester, menuButton);
 
       final menuDialog = find.byKey(const Key('mainMenuDialog'));
+      final closeButton = find.byKey(const Key('mainMenuCloseButton'));
       final menuDialogTop = tester.getTopLeft(menuDialog).dy;
+      final menuDialogLeft = tester.getTopLeft(menuDialog).dx;
+      final menuDialogWidth = tester.getSize(menuDialog).width;
+      final closeButtonLeft = tester.getTopLeft(closeButton).dx;
+      final closeButtonCenterY = tester.getCenter(closeButton).dy;
+      final aboutIconCenterY = tester.getCenter(find.byIcon(Icons.people)).dy;
+
       expect(find.byKey(const Key('mainMenuDialog')), findsOneWidget);
       expect(menuDialogTop, greaterThanOrEqualTo(menuButtonBottom));
       expect(menuDialogTop - menuButtonBottom, lessThan(20));
+      expect(menuDialogWidth, lessThanOrEqualTo(260));
+      expect(closeButtonLeft, lessThan(menuDialogLeft + menuDialogWidth / 2));
+      expect((closeButtonCenterY - aboutIconCenterY).abs(), lessThan(8));
+    });
+    testWidgets('Header menu puts close button on the right in English',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 900);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      await tester.pumpWidget(getMenuForTests(
+          mockUserInformation, mockAppInformation,
+          locale: const Locale('en')));
+      final menuButton = find.byIcon(Icons.menu);
+      final menuButtonBottom = tester.getBottomLeft(menuButton).dy;
+
+      await tapAndSettle(tester, menuButton);
+
+      final menuDialog = find.byKey(const Key('mainMenuDialog'));
+      final closeButton = find.byKey(const Key('mainMenuCloseButton'));
+      final menuDialogTop = tester.getTopLeft(menuDialog).dy;
+      final menuDialogLeft = tester.getTopLeft(menuDialog).dx;
+      final menuDialogWidth = tester.getSize(menuDialog).width;
+      final closeButtonLeft = tester.getTopLeft(closeButton).dx;
+
+      expect(menuDialogTop, greaterThanOrEqualTo(menuButtonBottom));
+      expect(menuDialogTop - menuButtonBottom, lessThan(20));
+      expect(
+          closeButtonLeft, greaterThan(menuDialogLeft + menuDialogWidth / 2));
     });
     testWidgets('Navigate from WellnessTools screen',
         (WidgetTester tester) async {

--- a/test/MenuTest/Wellness/wellnessTools_test.dart
+++ b/test/MenuTest/Wellness/wellnessTools_test.dart
@@ -12,6 +12,7 @@ import 'package:mazilon/pages/WellnessTools/more_videos_item.dart';
 import 'package:mazilon/pages/home.dart';
 import 'package:mazilon/pages/WellnessTools/wellnessTools.dart';
 import 'package:mazilon/util/persistent_memory_service.dart';
+import 'package:mazilon/util/styles.dart';
 
 import 'package:mazilon/util/userInformation.dart';
 import 'package:mazilon/util/appInformation.dart';
@@ -97,20 +98,36 @@ void main() {
       await tester.tap(finder);
       await tester.pumpAndSettle(const Duration(milliseconds: 200));
     }
+
     testWidgets('Navigate to WellnessTools screen',
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tapAndSettle(tester, find.text('תפריט'));
-      expect(find.byType(FractionallySizedBox), findsOneWidget);
       await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.byType(WellnessTools), findsOneWidget);
+    });
+    testWidgets('Header menu opens from hamburger icon',
+        (WidgetTester tester) async {
+      await tester
+          .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
+      final menuButton = find.byIcon(Icons.menu);
+      final menuIcon = tester.widget<Icon>(menuButton);
+      final menuButtonBottom = tester.getBottomLeft(menuButton).dy;
+
+      expect(menuIcon.color, primaryPurple);
+
+      await tapAndSettle(tester, menuButton);
+
+      final menuDialog = find.byKey(const Key('mainMenuDialog'));
+      final menuDialogTop = tester.getTopLeft(menuDialog).dy;
+      expect(find.byKey(const Key('mainMenuDialog')), findsOneWidget);
+      expect(menuDialogTop, greaterThanOrEqualTo(menuButtonBottom));
+      expect(menuDialogTop - menuButtonBottom, lessThan(20));
     });
     testWidgets('Navigate from WellnessTools screen',
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tapAndSettle(tester, find.text('תפריט'));
 
       await tapAndSettle(tester, find.text('כלי תמיכה'));
       await tapAndSettle(tester, find.text('בית'));
@@ -120,14 +137,12 @@ void main() {
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tapAndSettle(tester, find.text('תפריט'));
 
       await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.byType(WellnessTools), findsOneWidget);
       await tapAndSettle(tester, find.text('בית'));
       expect(find.byType(WellnessTools), findsNothing);
       expect(find.byType(Home), findsOneWidget);
-      await tapAndSettle(tester, find.text('תפריט'));
       await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.byType(Home), findsNothing);
       expect(find.byType(WellnessTools), findsOneWidget);
@@ -139,7 +154,6 @@ void main() {
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tapAndSettle(tester, find.text('תפריט'));
 
       await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.byType(FakeVideoPlayerPage), findsOneWidget);
@@ -150,7 +164,6 @@ void main() {
         (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tapAndSettle(tester, find.text('תפריט'));
 
       await tapAndSettle(tester, find.text('כלי תמיכה'));
       expect(find.text("Image"), findsOneWidget);
@@ -162,7 +175,6 @@ void main() {
     testWidgets('Test change video', (WidgetTester tester) async {
       await tester
           .pumpWidget(getMenuForTests(mockUserInformation, mockAppInformation));
-      await tapAndSettle(tester, find.text('תפריט'));
 
       await tapAndSettle(tester, find.text('כלי תמיכה'));
       await tapAndSettle(tester, find.text('v2'));

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mazilon/EmergencyNumbers.dart';
@@ -55,6 +57,8 @@ class FakeUrlLauncherPlatform extends UrlLauncherPlatform {
   }
 }
 
+const MethodChannel phoneChannel = MethodChannel('mazilon/phone');
+
 Widget buildEmergencyDialogTestApp({
   required EmergencyDialogBox dialog,
   required UserInformation userInformation,
@@ -100,12 +104,14 @@ Widget buildEmergencyGridTestApp({
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   test('Israel emergency numbers include correct Eran phone + WhatsApp', () {
     final israel = countries['israel'];
     expect(israel, isNotNull);
 
-    final eran =
-        israel!.emergencyNumbers.firstWhere((entry) => entry['name'] == 'ער\"ן');
+    final eran = israel!.emergencyNumbers
+        .firstWhere((entry) => entry['name'] == 'ער\"ן');
 
     expect(eran['number'], '1201');
     expect(eran['whatsapp'], true);
@@ -300,11 +306,56 @@ void main() {
     expect(fakePlatform.lastLaunchedUrl, 'sms:741741?body=HOME');
   });
 
-  test('dialPhone launches tel links without a canLaunch pre-check', () async {
+  test('dialPhone sends Android 4-digit short codes with a display hint',
+      () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(phoneChannel, (call) async {
+      calls.add(call);
+      return true;
+    });
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(phoneChannel, null);
+    });
+
+    await dialPhone(' 1201 ');
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'dial');
+    expect(calls.single.arguments, <String, String>{'number': '1201\u2060'});
+  });
+
+  test('dialPhone sends non-4-digit Android numbers unchanged', () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(phoneChannel, (call) async {
+      calls.add(call);
+      return true;
+    });
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(phoneChannel, null);
+    });
+
+    await dialPhone('105');
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'dial');
+    expect(calls.single.arguments, <String, String>{'number': '105'});
+  });
+
+  test('dialPhone uses url_launcher outside Android', () async {
     final originalPlatform = UrlLauncherPlatform.instance;
     final fakePlatform = FakeUrlLauncherPlatform();
     UrlLauncherPlatform.instance = fakePlatform;
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
     addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
       UrlLauncherPlatform.instance = originalPlatform;
     });
 

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mazilon/EmergencyNumbers.dart';
@@ -57,8 +56,6 @@ class FakeUrlLauncherPlatform extends UrlLauncherPlatform {
   }
 }
 
-const MethodChannel phoneChannel = MethodChannel('mazilon/phone');
-
 Widget buildEmergencyDialogTestApp({
   required EmergencyDialogBox dialog,
   required UserInformation userInformation,
@@ -110,8 +107,8 @@ void main() {
     final israel = countries['israel'];
     expect(israel, isNotNull);
 
-    final eran = israel!.emergencyNumbers
-        .firstWhere((entry) => entry['name'] == 'ער\"ן');
+    final eran =
+        israel!.emergencyNumbers.firstWhere((entry) => entry['name'] == 'ער"ן');
 
     expect(eran['number'], '1201');
     expect(eran['whatsapp'], true);
@@ -306,54 +303,11 @@ void main() {
     expect(fakePlatform.lastLaunchedUrl, 'sms:741741?body=HOME');
   });
 
-  test('dialPhone sends Android 4-digit short codes with a display hint',
-      () async {
-    final calls = <MethodCall>[];
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(phoneChannel, (call) async {
-      calls.add(call);
-      return true;
-    });
-    debugDefaultTargetPlatformOverride = TargetPlatform.android;
-    addTearDown(() {
-      debugDefaultTargetPlatformOverride = null;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(phoneChannel, null);
-    });
-
-    await dialPhone(' 1201 ');
-
-    expect(calls, hasLength(1));
-    expect(calls.single.method, 'dial');
-    expect(calls.single.arguments, <String, String>{'number': '1201\u2060'});
-  });
-
-  test('dialPhone sends non-4-digit Android numbers unchanged', () async {
-    final calls = <MethodCall>[];
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(phoneChannel, (call) async {
-      calls.add(call);
-      return true;
-    });
-    debugDefaultTargetPlatformOverride = TargetPlatform.android;
-    addTearDown(() {
-      debugDefaultTargetPlatformOverride = null;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(phoneChannel, null);
-    });
-
-    await dialPhone('105');
-
-    expect(calls, hasLength(1));
-    expect(calls.single.method, 'dial');
-    expect(calls.single.arguments, <String, String>{'number': '105'});
-  });
-
-  test('dialPhone uses url_launcher outside Android', () async {
+  test('dialPhone uses url_launcher for Android phone links', () async {
     final originalPlatform = UrlLauncherPlatform.instance;
     final fakePlatform = FakeUrlLauncherPlatform();
     UrlLauncherPlatform.instance = fakePlatform;
-    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
     addTearDown(() {
       debugDefaultTargetPlatformOverride = null;
       UrlLauncherPlatform.instance = originalPlatform;
@@ -361,7 +315,23 @@ void main() {
 
     await dialPhone('1201');
 
-    expect(fakePlatform.lastLaunchedUrl, 'tel:1201');
+    expect(fakePlatform.lastLaunchedUrl, 'tel:1201%20');
+  });
+
+  test('dialPhone does not add Android display hints to regular numbers',
+      () async {
+    final originalPlatform = UrlLauncherPlatform.instance;
+    final fakePlatform = FakeUrlLauncherPlatform();
+    UrlLauncherPlatform.instance = fakePlatform;
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      UrlLauncherPlatform.instance = originalPlatform;
+    });
+
+    await dialPhone('+9721201');
+
+    expect(fakePlatform.lastLaunchedUrl, 'tel:+9721201');
   });
 
   testWidgets('EmergencyDialogBox labels chat links as Chat', (tester) async {

--- a/test/l10n/locale_persistence_test.dart
+++ b/test/l10n/locale_persistence_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mazilon/global_enums.dart';
+import 'package:mazilon/util/Firebase/firebase_functions.dart';
+import 'package:mazilon/util/persistent_memory_service.dart';
+import 'package:mazilon/util/userInformation.dart';
+
+class FakePersistentMemoryService implements PersistentMemoryService {
+  FakePersistentMemoryService(this.values);
+
+  final Map<String, dynamic> values;
+
+  @override
+  Future<dynamic> getItem(String key, PersistentMemoryType type) async {
+    return values[key];
+  }
+
+  @override
+  Future<void> setItem(
+      String key, PersistentMemoryType type, dynamic value) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<void> reset() async {
+    values.clear();
+  }
+}
+
+void main() {
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  test('loadUserInformation keeps saved locale over device fallback', () async {
+    final service = FakePersistentMemoryService({
+      'localeName': 'en',
+    });
+    GetIt.instance.registerSingleton<PersistentMemoryService>(service);
+
+    final userInfo = UserInformation(service: service);
+    await loadUserInformation(userInfo, 'he');
+
+    expect(userInfo.localeName, 'en');
+  });
+}


### PR DESCRIPTION
## Summary

Closes #229.

This PR updates the main navigation flow so Support Tools are available directly from the bottom bar, while the general menu moves to the home header next to Settings.

## Changes

- Added a hamburger menu button to the Home header beside the Settings icon.
- Changed the hamburger icon color to the existing purple UI color.
- Moved the menu dialog so it opens near the hamburger button instead of from the bottom bar.
- Replaced the bottom-bar menu item with a direct Support Tools entry.
- Updated the Support Tools bottom-bar icon to a flower-style icon.
- Adjusted bottom-nav sizing so the Hebrew `כלי תמיכה` label fits without clipping or row overflow.
- Updated Wellness navigation widget tests for the new one-tap Support Tools flow and header menu behavior.

## Validation

- `flutter test test\MenuTest`
- `git diff --check`

## Notes

`flutter analyze` on the touched files still reports the existing `package_info_plus` direct dependency warning in `lib/menu.dart`. This PR does not change dependencies.

<img width="353" height="725" alt="image" src="https://github.com/user-attachments/assets/70e8d24c-8ace-45fb-bd50-7d6872338891" />
