### PR TITLE
Fix PR 251 navigation and emergency grid regressions

### DIFF
--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -1,5 +1,6 @@
 //import 'package:mazilon/pages/schedule.dart';
 
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
@@ -48,6 +49,10 @@ class Menu extends StatefulWidget {
 }
 
 class _MenuState extends LPExtendedState<Menu> {
+  static const double _bottomNavigationCenterGap = 72.0;
+
+  final AutoSizeGroup _bottomNavigationLabelGroup = AutoSizeGroup();
+
   PagesCode current = PagesCode.Home;
   String version = "1.0.0";
   bool isFullScreen = false;
@@ -219,6 +224,32 @@ class _MenuState extends LPExtendedState<Menu> {
     );
   }
 
+  Widget _bottomNavigationButton({
+    required Key key,
+    required VoidCallback onPressed,
+    required bool selected,
+    required IconData icon,
+    required String label,
+  }) {
+    return SizedBox.expand(
+      key: key,
+      child: TextButton(
+        style: TextButton.styleFrom(
+          padding: EdgeInsets.zero,
+          minimumSize: Size.zero,
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        onPressed: onPressed,
+        child: bottomNavigationItem(
+          selected,
+          icon,
+          label,
+          textGroup: _bottomNavigationLabelGroup,
+        ),
+      ),
+    );
+  }
+
   @override
   void initState() {
     loadFirstTime();
@@ -296,107 +327,71 @@ class _MenuState extends LPExtendedState<Menu> {
                 child: Container(
                   color: appWhite,
                   height: 60,
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      final navWidth = constraints.maxWidth;
-
-                      return Row(
-                        // mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Container(
-                            width: appLocale.localeName == 'en'
-                                ? navWidth / 6
-                                : navWidth / 8,
-                            alignment: appLocale.textDirection == "rtl"
-                                ? Alignment.centerLeft
-                                : Alignment.centerRight,
-                            child: TextButton(
-                                onPressed: () {
-                                  setState(() {
-                                    currentScreen = _buildHomeScreen();
-                                    current = PagesCode.Home;
-                                  });
-                                },
-                                child: bottomNavigationItem(
-                                    current == PagesCode.Home,
-                                    Icons.home,
-                                    appLocale.home(gender))),
-                          ),
-                          Container(
-                            alignment: appLocale.textDirection == "rtl"
-                                ? Alignment.centerLeft
-                                : Alignment.centerRight,
-                            width: appLocale.localeName == 'en'
-                                ? navWidth / 5
-                                : navWidth / 4,
-                            child: TextButton(
-                                onPressed: () {
-                                  setState(() {
-                                    currentScreen = MyPlanPageFull(
-                                      phonePageData: widget.phonePageData,
-                                      hasFilled: widget.hasFilled,
-                                      changeLocale: widget.changeLocale,
-                                    );
-                                    current = PagesCode.FullPlan;
-                                  });
-                                },
-                                child: bottomNavigationItem(
-                                    current == PagesCode.FullPlan,
-                                    Icons.assignment,
-                                    appLocale.personalPlanPageMyPlan(gender))),
-                          ),
-                          SizedBox(
-                            width: navWidth / 9,
-                          ),
-                          Container(
-                            alignment: appLocale.textDirection == "rtl"
-                                ? Alignment.centerLeft
-                                : Alignment.centerRight,
-                            width: navWidth / 4,
-                            child: TextButton(
-                                onPressed: () {
-                                  setState(() {
-                                    mixPanelService.trackEvent(
-                                      "Viewed Feel Good Page",
-                                    );
-                                    currentScreen = FeelGood();
-                                    current = PagesCode.FeelGoodPage;
-                                  });
-                                },
-                                child: bottomNavigationItem(
-                                    current == PagesCode.FeelGoodPage,
-                                    Icons.emoji_emotions_outlined,
-                                    AppLocalizations.of(context)!
-                                        .homePageFeelGood(gender))),
-                          ),
-                          SizedBox(
-                            width: appLocale.localeName == 'en'
-                                ? navWidth / 4
-                                : navWidth / 4.5,
-                            child: Align(
-                              alignment: appLocale.textDirection == "rtl"
-                                  ? Alignment.centerLeft
-                                  : Alignment.centerRight,
-                              child: TextButton(
-                                style: TextButton.styleFrom(
-                                  padding: EdgeInsets.zero,
-                                  minimumSize: Size.zero,
-                                  tapTargetSize:
-                                      MaterialTapTargetSize.shrinkWrap,
-                                ),
-                                onPressed: () {
-                                  _showWellnessTools(appInfoProvider);
-                                },
-                                child: bottomNavigationItem(
-                                    current == PagesCode.WellnessToolsPage,
-                                    Icons.local_florist_outlined,
-                                    appLocale.homePageWellnessTools(gender)),
-                              ),
-                            ),
-                          ),
-                        ],
-                      );
-                    },
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: _bottomNavigationButton(
+                          key: const Key('bottomNavHome'),
+                          onPressed: () {
+                            setState(() {
+                              currentScreen = _buildHomeScreen();
+                              current = PagesCode.Home;
+                            });
+                          },
+                          selected: current == PagesCode.Home,
+                          icon: Icons.home,
+                          label: appLocale.home(gender),
+                        ),
+                      ),
+                      Expanded(
+                        child: _bottomNavigationButton(
+                          key: const Key('bottomNavMyPlan'),
+                          onPressed: () {
+                            setState(() {
+                              currentScreen = MyPlanPageFull(
+                                phonePageData: widget.phonePageData,
+                                hasFilled: widget.hasFilled,
+                                changeLocale: widget.changeLocale,
+                              );
+                              current = PagesCode.FullPlan;
+                            });
+                          },
+                          selected: current == PagesCode.FullPlan,
+                          icon: Icons.assignment,
+                          label: appLocale.personalPlanPageMyPlan(gender),
+                        ),
+                      ),
+                      const SizedBox(width: _bottomNavigationCenterGap),
+                      Expanded(
+                        child: _bottomNavigationButton(
+                          key: const Key('bottomNavFeelGood'),
+                          onPressed: () {
+                            setState(() {
+                              mixPanelService.trackEvent(
+                                "Viewed Feel Good Page",
+                              );
+                              currentScreen = FeelGood();
+                              current = PagesCode.FeelGoodPage;
+                            });
+                          },
+                          selected: current == PagesCode.FeelGoodPage,
+                          icon: Icons.emoji_emotions_outlined,
+                          label: AppLocalizations.of(context)!
+                              .homePageFeelGood(gender),
+                        ),
+                      ),
+                      Expanded(
+                        child: _bottomNavigationButton(
+                          key: const Key('bottomNavSupportTools'),
+                          onPressed: () {
+                            _showWellnessTools(appInfoProvider);
+                          },
+                          selected: current == PagesCode.WellnessToolsPage,
+                          icon: Icons.local_florist_outlined,
+                          label: appLocale.homePageWellnessTools(gender),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/lib/util/HomePage/bottomNavigationItem.dart
+++ b/lib/util/HomePage/bottomNavigationItem.dart
@@ -1,10 +1,16 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import 'package:mazilon/util/styles.dart';
 
 //Item for the bottom Navigation in the home page
-Widget bottomNavigationItem(bool current, IconData icon, String text) {
+Widget bottomNavigationItem(
+  bool current,
+  IconData icon,
+  String text, {
+  AutoSizeGroup? textGroup,
+}) {
   Color color = current ? primaryPurple : darkGray;
   return Column(
     mainAxisAlignment: MainAxisAlignment.center,
@@ -18,13 +24,16 @@ Widget bottomNavigationItem(bool current, IconData icon, String text) {
       Expanded(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 2),
-          child: myAutoSizedText(
-              text,
-              TextStyle(
-                  fontWeight: FontWeight.bold, color: color, fontSize: 14.sp),
-              null,
-              25,
-              1),
+          child: AutoSizeText(text,
+              group: textGroup,
+              maxFontSize: 25,
+              style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: color,
+                      fontSize: 14.sp)
+                  .copyWith(fontFamily: 'Rubix'),
+              textAlign: TextAlign.center,
+              maxLines: 1),
         ),
       )
     ],

--- a/lib/util/Phone/EmergencyPhones.dart
+++ b/lib/util/Phone/EmergencyPhones.dart
@@ -12,8 +12,27 @@ List<Widget> extractChildrenFromRow(Row row) {
   return row.children;
 }
 
+List<Map<String, dynamic>> _hebrewIsraelEmergencyOrder(
+    List<Map<String, dynamic>> numbers) {
+  final orderedNumbers = List<Map<String, dynamic>>.of(numbers);
+  final index105 =
+      orderedNumbers.indexWhere((number) => number['number'] == '105');
+  final saharIndex =
+      orderedNumbers.indexWhere((number) => number['number'] == '0559571399');
+
+  if (index105 != -1 && saharIndex != -1) {
+    final number105 = orderedNumbers[index105];
+    orderedNumbers[index105] = orderedNumbers[saharIndex];
+    orderedNumbers[saharIndex] = number105;
+  }
+
+  return orderedNumbers;
+}
+
 // A stateless widget that displays a grid of emergency phone items
 class EmergencyPhonesGrid extends StatelessWidget {
+  const EmergencyPhonesGrid({super.key});
+
   @override
   Widget build(BuildContext context) {
     final userInfo = Provider.of<UserInformation>(context, listen: true);
@@ -28,27 +47,33 @@ class EmergencyPhonesGrid extends StatelessWidget {
       debugPrint(
           'No emergency mapping for countryCode="$countryCode". Using default "${defaultEmergencyCountry.id}".');
     }
-    final localNumbers = (country ?? defaultEmergencyCountry).emergencyNumbers;
+    final activeCountry = country ?? defaultEmergencyCountry;
+    final localNumbers = activeCountry.emergencyNumbers;
+    final appLocale = AppLocalizations.of(context);
+    final displayedNumbers =
+        appLocale?.localeName == 'he' && activeCountry.id == 'israel'
+            ? _hebrewIsraelEmergencyOrder(localNumbers)
+            : localNumbers;
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: LayoutBuilder(
         builder: (context, constraints) {
           const spacing = 10.0;
-          final crossAxisCount = constraints.maxWidth < 600 ? 1 : 2;
-          final itemWidth = crossAxisCount == 1
-              ? constraints.maxWidth
-              : (constraints.maxWidth - spacing) / crossAxisCount;
+          final crossAxisCount = constraints.maxWidth < 320 ? 1 : 2;
+          final itemWidth =
+              (constraints.maxWidth - spacing * (crossAxisCount - 1)) /
+                  crossAxisCount;
 
           return Wrap(
             spacing: spacing,
             runSpacing: spacing,
             children: [
-              for (int index = 0; index < localNumbers.length; index++)
+              for (int index = 0; index < displayedNumbers.length; index++)
                 SizedBox(
                   width: itemWidth,
                   child: EmergencyPhoneItem(
                     i: index,
-                    number: localNumbers[index],
+                    number: displayedNumbers[index],
                   ),
                 ),
             ],

--- a/test/MenuTest/reminder_visibility_test.dart
+++ b/test/MenuTest/reminder_visibility_test.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -42,7 +43,8 @@ class _FakePersistentMemoryService implements PersistentMemoryService {
   Future<void> reset() async {}
 
   @override
-  Future<void> setItem(String key, PersistentMemoryType type, dynamic value) async {}
+  Future<void> setItem(
+      String key, PersistentMemoryType type, dynamic value) async {}
 }
 
 class _FakeFileService implements FileService {
@@ -74,12 +76,15 @@ class _FakeFileService implements FileService {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final hebrewHome = String.fromCharCodes([0x05D1, 0x05D9, 0x05EA]);
+
   late UserInformation mockUserInformation;
   late AppInformation mockAppInformation;
 
   setUp(() async {
     await GetIt.instance.reset();
-    getIt.registerLazySingleton<AnalyticsService>(() => _FakeAnalyticsService());
+    getIt
+        .registerLazySingleton<AnalyticsService>(() => _FakeAnalyticsService());
     getIt.registerLazySingleton<FileService>(() => _FakeFileService());
     getIt.registerLazySingleton<PersistentMemoryService>(
       () => _FakePersistentMemoryService(),
@@ -108,6 +113,63 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  Future<void> pumpMenu(
+    WidgetTester tester, {
+    Locale locale = const Locale('he'),
+    Size? physicalSize,
+  }) async {
+    if (physicalSize != null) {
+      tester.view.physicalSize = physicalSize;
+      tester.view.devicePixelRatio = 1;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+    }
+
+    await tester.pumpWidget(
+      getMenuForTests(
+        mockUserInformation,
+        mockAppInformation,
+        locale: locale,
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  List<Finder> bottomNavButtons() {
+    return [
+      find.byKey(const Key('bottomNavHome')),
+      find.byKey(const Key('bottomNavMyPlan')),
+      find.byKey(const Key('bottomNavFeelGood')),
+      find.byKey(const Key('bottomNavSupportTools')),
+    ];
+  }
+
+  void expectSymmetricBottomNav(WidgetTester tester) {
+    final buttons = bottomNavButtons();
+    for (final button in buttons) {
+      expect(button, findsOneWidget);
+    }
+
+    final widths = buttons.map((button) => tester.getSize(button).width);
+    for (final width in widths.skip(1)) {
+      expect(width, closeTo(widths.first, 0.1));
+    }
+
+    final homeCenter = tester.getCenter(buttons[0]).dx;
+    final planCenter = tester.getCenter(buttons[1]).dx;
+    final feelGoodCenter = tester.getCenter(buttons[2]).dx;
+    final supportToolsCenter = tester.getCenter(buttons[3]).dx;
+
+    final outerLeftGap = (homeCenter - planCenter).abs();
+    final outerRightGap = (supportToolsCenter - feelGoodCenter).abs();
+    final centerGap = (planCenter - feelGoodCenter).abs();
+
+    expect(outerRightGap, closeTo(outerLeftGap, 0.1));
+    expect(centerGap - outerLeftGap, closeTo(72, 0.1));
+  }
+
   testWidgets('hides the reminders menu entry on iOS', (
     WidgetTester tester,
   ) async {
@@ -132,5 +194,48 @@ void main() {
     } finally {
       debugDefaultTargetPlatformOverride = null;
     }
+  });
+
+  testWidgets('keeps Hebrew bottom navigation labels visible and symmetric', (
+    WidgetTester tester,
+  ) async {
+    await pumpMenu(tester);
+
+    expect(find.text(hebrewHome), findsOneWidget);
+    expectSymmetricBottomNav(tester);
+  });
+
+  testWidgets('keeps Hebrew bottom navigation labels in one sizing group', (
+    WidgetTester tester,
+  ) async {
+    await pumpMenu(tester);
+
+    final groups = <AutoSizeGroup?>[];
+    for (final button in bottomNavButtons()) {
+      final label = find.descendant(
+        of: button,
+        matching: find.byType(AutoSizeText),
+      );
+      expect(label, findsOneWidget);
+      groups.add(tester.widget<AutoSizeText>(label).group);
+    }
+
+    expect(groups.first, isNotNull);
+    for (final group in groups.skip(1)) {
+      expect(group, same(groups.first));
+    }
+  });
+
+  testWidgets('keeps English bottom navigation slots symmetric', (
+    WidgetTester tester,
+  ) async {
+    await pumpMenu(
+      tester,
+      locale: const Locale('en'),
+      physicalSize: const Size(1200, 1000),
+    );
+
+    expect(find.text('Home'), findsOneWidget);
+    expectSymmetricBottomNav(tester);
   });
 }

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -103,6 +103,9 @@ Widget buildEmergencyGridTestApp({
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final hebrewEran = String.fromCharCodes([0x05E2, 0x05E8, 0x0022, 0x05DF]);
+  final hebrewSahar = String.fromCharCodes([0x05E1, 0x05D4, 0x0022, 0x05E8]);
+
   test('Israel emergency numbers include correct Eran phone + WhatsApp', () {
     final israel = countries['israel'];
     expect(israel, isNotNull);
@@ -382,5 +385,79 @@ void main() {
     expect(find.text('Samaritans'), findsOneWidget);
     expect(find.text('Shout'), findsOneWidget);
     expect(find.text('Veterans Crisis Line'), findsNothing);
+  });
+
+  testWidgets('EmergencyPhonesGrid uses two columns on phone width',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final userInfo = UserInformation(
+      gender: 'male',
+      location: 'US',
+      service: FakePersistentMemoryService(),
+    );
+
+    await tester.pumpWidget(
+      buildEmergencyGridTestApp(userInformation: userInfo),
+    );
+
+    await tester.pumpAndSettle();
+
+    final emergency = find.text('Emergency');
+    final veterans = find.text('Veterans Crisis Line');
+    expect(emergency, findsOneWidget);
+    expect(veterans, findsOneWidget);
+
+    final emergencyTop = tester.getTopLeft(emergency).dy;
+    final veteransTop = tester.getTopLeft(veterans).dy;
+    final emergencyLeft = tester.getTopLeft(emergency).dx;
+    final veteransLeft = tester.getTopLeft(veterans).dx;
+
+    expect(veteransTop, closeTo(emergencyTop, 1));
+    expect(veteransLeft, greaterThan(emergencyLeft));
+  });
+
+  testWidgets('Hebrew Israel emergency grid puts Sahar beside Eran',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final userInfo = UserInformation(
+      gender: 'male',
+      location: 'IL',
+      service: FakePersistentMemoryService(),
+    );
+
+    await tester.pumpWidget(
+      buildEmergencyGridTestApp(
+        userInformation: userInfo,
+        locale: const Locale('he'),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final eran = find.text(hebrewEran);
+    final sahar = find.text(hebrewSahar);
+    final number105 = find.text('105');
+    expect(eran, findsOneWidget);
+    expect(sahar, findsOneWidget);
+    expect(number105, findsOneWidget);
+
+    final eranTop = tester.getTopLeft(eran).dy;
+    final saharTop = tester.getTopLeft(sahar).dy;
+    final number105Top = tester.getTopLeft(number105).dy;
+
+    expect(saharTop, closeTo(eranTop, 1));
+    expect(number105Top, greaterThan(eranTop + 20));
   });
 }


### PR DESCRIPTION
## Summary

This hotfix addresses UI regressions introduced by PR #251:

- Fixes bottom navbar spacing by using four equal-width nav slots around the centered SOS button.
- Keeps bottom navbar label font sizes consistent across all buttons.
- Restores the full Hebrew Home label: 'בית'.
- Restores emergency numbers to a 2-column layout on normal phone-width screens.
- In Hebrew Israel SOS, places 'סה"ר' on the same row as 'ער"ן', with '105' below.

## Validation

- 'flutter test test/MenuTest/reminder_visibility_test.dart test/MenuTest/Wellness/wellnessTools_test.dart test/emergency_whatsapp_test.dart'
  - Passed: 24 tests.
- 'flutter build apk --debug'
  - Passed.
- Pixel 9a2 emulator QA:
  - Hebrew home/navbar screenshot checked.
  - Hebrew emergency numbers screenshot checked.
  - UI tree verified full 'בית', symmetric navbar bounds, two-column emergency grid, and 'סה"ר' beside 'ער"ן'.
  - Crash buffer was empty after launch/navigation.

## Notes

'flutter analyze' on the touched files still reports the pre-existing 'package_info_plus' dependency info in 'lib/menu.dart' and 'test/MenuTest/reminder_visibility_test.dart'. This hotfix leaves that cleanup out of scope.
