### PR TITLE
ADR-005 Phase A: S0 crisis-path hardening

### DIFF
--- a/.claude-flow/agents/store.json
+++ b/.claude-flow/agents/store.json
@@ -1,0 +1,64 @@
+{
+  "agents": {
+    "agent-1779652135585-o9b2sk": {
+      "agentId": "agent-1779652135585-o9b2sk",
+      "agentType": "coder",
+      "status": "idle",
+      "health": 1,
+      "taskCount": 0,
+      "config": {
+        "adr": "ADR-005",
+        "phase": "A.1",
+        "files": [
+          "lib/util/Phone/phoneTextAndIcon.dart",
+          "lib/util/Phone/emergencyDialogBox.dart",
+          "test/Phone/phoneTextAndIcon_test.dart"
+        ],
+        "model": "sonnet"
+      },
+      "createdAt": "2026-05-24T19:48:55.585Z",
+      "domain": "flutter-ux",
+      "model": "sonnet",
+      "modelRoutedBy": "explicit"
+    },
+    "agent-1779652140959-hzkkjv": {
+      "agentId": "agent-1779652140959-hzkkjv",
+      "agentType": "coder",
+      "status": "idle",
+      "health": 1,
+      "taskCount": 0,
+      "config": {
+        "adr": "ADR-005",
+        "phase": "A.2",
+        "files": [
+          "lib/menu.dart"
+        ],
+        "model": "sonnet"
+      },
+      "createdAt": "2026-05-24T19:49:00.959Z",
+      "domain": "flutter-ux",
+      "model": "sonnet",
+      "modelRoutedBy": "explicit"
+    },
+    "agent-1779652145837-xu49zj": {
+      "agentId": "agent-1779652145837-xu49zj",
+      "agentType": "coder",
+      "status": "idle",
+      "health": 1,
+      "taskCount": 0,
+      "config": {
+        "adr": "ADR-005",
+        "phase": "A.3",
+        "files": [
+          "lib/util/Phone/EmergencyPhones.dart"
+        ],
+        "model": "sonnet"
+      },
+      "createdAt": "2026-05-24T19:49:05.837Z",
+      "domain": "flutter-ux",
+      "model": "sonnet",
+      "modelRoutedBy": "explicit"
+    }
+  },
+  "version": "3.0.0"
+}

--- a/.claude-flow/swarm/swarm-state.json
+++ b/.claude-flow/swarm/swarm-state.json
@@ -1,0 +1,28 @@
+{
+  "swarms": {
+    "swarm-1779652129553-7uhz9k": {
+      "swarmId": "swarm-1779652129553-7uhz9k",
+      "topology": "hierarchical",
+      "maxAgents": 8,
+      "status": "terminated",
+      "agents": [
+        "agent-1779652135585-o9b2sk",
+        "agent-1779652140959-hzkkjv",
+        "agent-1779652145837-xu49zj"
+      ],
+      "tasks": [],
+      "config": {
+        "topology": "hierarchical",
+        "maxAgents": 8,
+        "strategy": "specialized",
+        "communicationProtocol": "message-bus",
+        "autoScaling": true,
+        "consensusMechanism": "majority"
+      },
+      "createdAt": "2026-05-24T19:48:49.553Z",
+      "updatedAt": "2026-05-24T20:09:09.398Z",
+      "pid": 59820
+    }
+  },
+  "version": "3.0.0"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ lib/util/Firebase/firebase_options.dart
 ruvector.db
 *.local.json
 
+.claude/
+.codex/

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ ruvector.db
 
 .claude/
 .codex/
+.claude-flow/

--- a/docs/UX_GAPS.md
+++ b/docs/UX_GAPS.md
@@ -1,0 +1,194 @@
+# Mazilon — UX Gaps Audit
+
+**Date:** 2026-05-24
+**Scope:** Flutter mental-health support app (Hebrew/English, iOS + Android + Web)
+**Method:** Static read of `lib/` (pages, helpers, styles, navigation) — no device run. Findings reference `file:line` so issues can be reproduced and triaged.
+
+This document is a prioritized inventory of UX gaps, not a fix plan. Each finding lists severity, the surface affected, and observable evidence. Severities follow this scale:
+
+| Sev | Meaning |
+|-----|---------|
+| **S0** | Blocks a crisis-time task or risks user harm (silent failure on emergency call, trapped flow) |
+| **S1** | Accessibility / safety regression for vulnerable users (touch targets, screen readers, locale) |
+| **S2** | Visible polish / correctness gap that erodes trust |
+| **S3** | Inconsistency or maintainability issue with downstream UX cost |
+
+---
+
+## 1. Cross-cutting findings
+
+### 1.1 No design-system tokens (S3)
+`lib/util/styles.dart:5-13` hardcodes nine palette colors as top-level mutable `Color` variables. There is no `ThemeData`, no semantic token (`onSurface`, `error`, `success`), no dark-mode definition, and no opacity ramp. Throughout the app, `Colors.blue`, `Colors.red`, `Colors.black45`, and one-off `Color.fromARGB(255, 68, 0, 255)` (`lib/pages/UserSettings.dart:267`) appear alongside the brand palette — i.e. the palette is decorative, not enforced.
+
+**Consequences observed downstream:** destructive buttons styled with raw `Colors.red` (`myButtonStyle3`, `styles.dart:36-40`) instead of a semantic `error` token; locale-dropdown selected text in bright violet that does not appear elsewhere in the app; no way to do dark-mode in one PR.
+
+### 1.2 Theme/MaterialApp does not define `theme:` (S2)
+`lib/main.dart:410-428` constructs `MaterialApp` with no `theme` or `darkTheme`. Default Material 2 styles apply, with the brand palette layered on top piecewise. This is why focus rings, ripple colors, dialog backgrounds, and `TextSelectionTheme` are inconsistent across pages.
+
+### 1.3 Screen-reader labels missing on icon-only controls (S1)
+Icon buttons across the app are bare `IconButton` / `myTextButton` without `Semantics(label:)` or `tooltip:`. Verified in:
+- `lib/pages/home.dart:150-154` — hamburger menu button
+- `lib/pages/journal.dart:236-247` — add-entry button
+- `lib/MainPageHelpers/personalPlanWidget.dart:108-136` — share & download buttons
+- `lib/util/HomePage/inspirationalQuote.dart:74,84-91` — close & refresh
+- `lib/util/Phone/phoneTextAndIcon.dart:11-20,102,106` — dialer affordances
+
+For a mental-health app, TalkBack/VoiceOver coverage is not optional. Crisis users include people with visual impairment.
+
+### 1.4 RTL / Hebrew alignment is inconsistent (S1)
+The app supports `he` and `en`, but RTL handling is implemented ad-hoc rather than via `Directionality`-aware widgets:
+- `lib/main_menu_dialog.dart:97-99` sets `textDirection: isRtl ? TextDirection.ltr : TextDirection.rtl` — inverted.
+- `lib/util/HomePage/NameBar.dart:38` forces `CrossAxisAlignment.start` regardless of locale.
+- `lib/util/HomePage/inspirationalQuote.dart:99-101` toggles padding `30.0` ↔ `0` between RTL and LTR — asymmetric on locale swap.
+- `lib/MainPageHelpers/personalPlanWidget.dart:164-178` swaps the arrow icon for RTL but the surrounding `Row` keeps default LTR alignment.
+- `lib/main_menu_dialog.dart:140,163,183` — menu rows pinned to `mainAxisAlignment.start` (should be `end` in RTL).
+
+A Hebrew user sees jagged padding shifts and misplaced glyphs each time the locale changes.
+
+### 1.5 No global loading / error contract (S2)
+Async flows (form retrieval, video player init, share-sheet, locale change, quote fetch) have no shared loading affordance. Common pattern: a `FutureBuilder` shows `CircularProgressIndicator` only for `ConnectionState.waiting` and silently renders nothing on error.
+
+Examples:
+- `lib/pages/FeelGood/feelGood.dart:105-139` — `error` branch missing
+- `lib/MainPageHelpers/personalPlanWidget.dart:113-136` — toast "finished" fires even if file write failed
+- `lib/util/Phone/phoneTextAndIcon.dart:39-43` — `dialPhone` swallows `launchUrl` failures
+- `lib/pages/SignIn_Pages/introduction.dart:45-48` — loader has no timeout and no `Semantics` label
+
+### 1.6 Touch targets routinely below 44 dp (S1)
+- `lib/util/Phone/phoneTextAndIcon.dart:11-20` — `CircleAvatar(radius: 20)` is a 40 dp dialer target.
+- `lib/pages/thankYou.dart:114-144` — edit/delete `MaterialButton` cluster lacks padding; transparent `splashColor` removes tap affordance.
+- `lib/pages/UserSettings.dart:228-235` — `height: 35`, vertical content-padding `6.0` — input field is barely tap-able and the cursor target is even smaller.
+- `lib/menu.dart:295-308` — SOS FAB uses an unscaled `fontSize: 10`; label can become unreadable while text-scale is large, while the FAB itself is hidden during full-screen video (`menu.dart:289`).
+
+### 1.7 Fixed font sizes bypass user system text-scale (S1)
+`flutter_screenutil` (`.sp`) is used inconsistently. Fixed sizes appear in:
+- `lib/pages/thankYou.dart:101` (`fontSize: 20`)
+- `lib/pages/FeelGood/feelGood.dart:86-93` (`fontSize: 30`)
+- `lib/menu.dart:303` (`fontSize: 10`)
+- `lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart:50-52` (`min(24, 14.sp)` clamps *upward* on large screens)
+
+Users who enlarge system text — common in mental-health and elderly demographics — see clipped or shrunken UI.
+
+---
+
+## 2. Crisis & safety flow (S0/S1) — highest priority
+
+The app's most load-bearing flow is "the user is in distress and needs a number". Findings here block or degrade that flow.
+
+### 2.1 SOS is hidden when the user is most likely to need it (S0)
+`lib/menu.dart:289` hides the SOS FAB *and* the bottom nav (`menu.dart:320`) whenever `isFullScreen == true` — i.e., while watching a Wellness Tools video. There is no alternative crisis affordance during that state. A user who is triggered mid-video has no fast path to an emergency number.
+
+### 2.2 Dial-failure is silent (S0)
+`lib/util/Phone/phoneTextAndIcon.dart:39-43` calls `launchUrl(...)` inside try/await with no error UI. If the OS rejects the URI (sim missing, restricted profile, malformed 4-digit number on iOS, denied permission), the user believes the call is dialing. There is no haptic, snackbar, or fallback "Copy number" action. This is the single highest-risk gap in the codebase.
+
+Related: `phoneTextAndIcon.dart:55-61` (`openWhatsApp`) and `:71-84` (`openTextMessage`) have the same silent-failure shape.
+
+### 2.3 Emergency grid falls back to wrong country silently (S1)
+`lib/util/Phone/EmergencyPhones.dart:45-50` reverts to `defaultEmergencyCountry` if country detection fails. The user is never told. In a Hebrew-speaking user roaming abroad, they may see Israeli numbers that won't connect.
+
+### 2.4 Emergency-add not reachable from Emergency page (S2)
+Adding a personal emergency contact is only available from Settings (`lib/pages/UserSettings.dart`) and from the initial-form flow. `lib/pages/phone.dart` itself has no "add my own number" affordance — a discoverability gap on the page where the intent is most likely formed.
+
+### 2.5 Disclaimer is a wall-of-text trap (S1)
+`lib/disclaimerPage.dart:57` sets `PopScope(canPop: false)`. `:68-91` renders two long Hebrew/English paragraphs with no headings, no progress indicator, no "read more" pacing. `.sp` font scaling on a tablet maxes the body text at `40` (`:77,91`), pushing it past readable line length. A user already in distress cannot exit, cannot skim, and cannot tell how much more they must scroll.
+
+---
+
+## 3. Page-by-page findings
+
+### 3.1 Home — `lib/pages/home.dart`
+- **(S2)** `:133` calls `setRandomPersonalWidgetText(...)` from inside `build()`. Each rebuild re-randomises the headline copy; the personal-plan widget flickers between four states on locale change, scroll, theme refresh, or any provider notify. Anti-pattern — should be in `initState` / `didChangeDependencies`.
+- **(S2)** `:137-139` `AppBar(scrolledUnderElevation: 0, backgroundColor: lightGray)` on a `lightGray` body removes the bar boundary entirely on scroll. No drop shadow, no divider — header becomes invisible against scrolling content.
+- **(S3)** `:192` adds a bare `SizedBox(height: 70)` at the bottom to clear the FAB. Magic number tied to FAB size in `menu.dart:52`.
+
+### 3.2 Personal Plan widget — `lib/MainPageHelpers/personalPlanWidget.dart`
+- **(S2)** `:140-157` `GridView` aspect ratio `12 / 4` ignores content length; long Hebrew bullets overflow with no `TextOverflow` strategy.
+- **(S2)** `:127` Download success toast fires unconditionally regardless of file-write outcome.
+- **(S1)** `:159-179` "View All" is a `GestureDetector` with no `Semantics(button: true)` and no ripple — feels like static text to keyboard / screen-reader users.
+
+### 3.3 Inspirational Quote — `lib/util/HomePage/inspirationalQuote.dart`
+- **(S2)** `:62` Container height fixed at `120` — long Hebrew quotes clip.
+- **(S1)** `:104` `widget.quotes[number]` indexes without bounds check; empty list crashes.
+- **(S2)** `:52` Once dismissed via `Visibility(visible: showText)` there is no undo control. The user cannot bring the quote back without re-launching.
+
+### 3.4 Gratitude Journal — `lib/pages/journal.dart`
+- **(S1)** `:62-67` / `:209` FocusNodes appear to be created during `build` rather than in `initState`; potential leak + focus jump on every rebuild.
+- **(S2)** `:291` Empty state renders `Container()` — user sees nothing where the empty-state guidance should be.
+- **(S0-adjacent S2)** `:333` `sug1 = thanksSuggestionList[indices[0]]` crashes if `thanksSuggestionList` is empty. For a gratitude prompt the worst case is a crash, but a crash on first run is a retention killer.
+- **(S2)** `:150-177` "First entry" celebration popup is delayed 10 s, locking the screen; user has already moved on.
+
+### 3.5 Positive Traits — `lib/pages/positive.dart`
+- **(S2)** `:128-156` Modal popup fires after a fixed 10 s delay, every entry into the page, with no "don't show again" — classic nag.
+- **(S2)** `:282-299` Three-suggestion UI uses pairwise `!=` checks; identical short lists collapse to a single rendered suggestion silently.
+- **(S1)** `:225-241` `Expanded` + conditional `TextAlign` only handles RTL; LTR leaves alignment to default.
+
+### 3.6 Thank-you entry widget — `lib/pages/thankYou.dart`
+- **(S1)** `:114-144` Edit/delete buttons lack labels, lack confirmation, lack haptic. A misclicked delete on a journal entry has no undo.
+- **(S2)** `:101` Fixed `fontSize: 20` + `TextOverflow.ellipsis` truncates without an expand affordance.
+
+### 3.7 Phone / Emergency — `lib/pages/phone.dart` & helpers
+- See §2 above for S0 findings.
+- **(S2)** `phone.dart:78-84` Disclaimer paragraph at top of page is long-form, not scannable, and competes for attention with the emergency grid.
+- **(S2)** `EmergencyPhones.dart:62-82` `minHeight: 170` for items forces vertical scroll of the *emergency* list on small phones.
+- **(S1)** `EmergencyPhones.dart:101-188` `InkWell` items have no hover/pressed visual delta and no `Semantics`.
+
+### 3.8 User Settings — `lib/pages/UserSettings.dart`
+- **(S2)** `:227-244` Container `width: 300` hardcoded; on phones < 360 dp the form overflows.
+- **(S2)** `:267,310` Selected dropdown text in `ARGB(255,68,0,255)` — a color that exists nowhere else in the app.
+- **(S2)** `:298-303` Gender selection logic relies on nested ternaries that don't reconcile cleanly when `binary=true, gender='male'` — UI shows `nonBinary` selected.
+- **(S1)** No validation feedback on empty name; submit silently no-ops or applies an empty string.
+- **(S2)** Locale dropdown changes locale but does not re-render localized strings until next route push (verify on device).
+- **(S2)** `:400-474` Reset confirmation `Dialog` ignores Material insets; full-width on landscape.
+
+### 3.9 Wellness Tools — `lib/pages/WellnessTools/wellnessTools.dart`
+- **(S1)** `:161-193` No captions / transcripts for video content — failing WCAG 1.2.x for prerecorded media in a mental-health app.
+- **(S2)** `:66-72` Empty state uses fixed `18.sp` without `AutoSizeText` — overflows on small phones.
+- **(S2)** `:100,126,144` Fullscreen text toggle is not animated; chrome appears/disappears abruptly.
+- **(S0-adjacent S1)** See §2.1 — fullscreen hides crisis affordance.
+
+### 3.10 Feel Good — `lib/pages/FeelGood/feelGood.dart`
+- **(S1)** `:61-74` `PreferredSize` AppBar `150` dp with no `SafeArea`; logo can overlap status bar on notched devices.
+- **(S2)** `:105-139` `FutureBuilder` error branch unhandled; failure renders empty grid.
+- **(S2)** `:57-59` Image delete is immediate, no undo, no confirmation.
+- **(S3)** `:86-93` Title `fontSize: 30` not `.sp`.
+
+### 3.11 Navigation — `lib/menu.dart` & `lib/main_menu_dialog.dart`
+- See §2.1 for fullscreen-hides-everything (S0).
+- **(S2)** `menu.dart:277-281` Back button logic only kicks in when `current == Home`; deeper pages have no in-app back affordance.
+- **(S1)** `menu.dart:327-397` Bottom nav buttons have no `Semantics` `selected:` state — screen reader cannot announce active tab.
+- **(S2)** `main_menu_dialog.dart:52-70` Dialog positioning recomputes from `RenderBox` lookup with unsafe fallback; on edge cases the menu can render off-screen.
+- **(S1)** `main_menu_dialog.dart:97-99` Inverted RTL `textDirection` (see §1.4).
+
+### 3.12 Sign-in flow — `lib/pages/SignIn_Pages/`
+- **(S2)** `introduction.dart:38,45-48` Loading screen uses raw `Colors.blue` and an unlabeled `CircularProgressIndicator`.
+- **(S2)** `firstPage.dart:37-56` Routing tree mixes `enteredBefore`, `disclaimerSigned`, `firsttime`, and `hasFilled` flags with overlapping conditions; one branch can render an unhandled blank state.
+
+---
+
+## 4. Recommended next steps
+
+These are *not* part of the gap audit; they're the suggested triage order if you commit to addressing the above.
+
+1. **Crisis path hardening (S0):** wire `launchUrl` failures to a visible fallback (snackbar + tappable "Copy number"); show SOS even in full-screen video; surface country-fallback notice in `EmergencyPhones.dart`.
+2. **Accessibility pass (S1):** add `Semantics(label:)` / `tooltip:` to every icon-only control along the home → plan → phone path; replace fixed font sizes with `.sp` where the surrounding widget already opts in.
+3. **RTL pass (S1):** stop branching on `isRtl` for `textDirection`/padding; lean on `Directionality.of(context)` and start/end edge insets.
+4. **Theme + tokens (S3 → unlocks S2 fixes):** define `ThemeData` (light + dark), move palette to semantic tokens, replace `Colors.red` destructive buttons with `colorScheme.error`.
+5. **Loading/error contract (S2):** one shared `AsyncValue`-style widget (loading / error-with-retry / empty / data) and route every `FutureBuilder` through it.
+
+---
+
+## 5. Appendix — design-system reference (target state)
+
+A reference design system was generated for this app via the `ui-ux-pro-max` skill (mental-health / wellness profile):
+
+| Role | Token | Hex |
+|------|-------|-----|
+| Primary | `primary` | `#8B5CF6` (calming lavender — close to existing `primaryPurple #A688F8`) |
+| Secondary | `secondary` | `#C4B5FD` |
+| CTA / success | `success` | `#10B981` (replaces ad-hoc `appGreen`) |
+| Background | `surface` | `#FAF5FF` |
+| Text | `onSurface` | `#4C1D95` |
+
+Typography target: **Lora** (headings) + **Raleway** (body) — calm/wellness pairing. Current app uses `Rubix` for all text (`styles.dart:100,112`) which biases playful rather than supportive; worth A/B'ing.
+
+Anti-patterns to avoid when remediating: flat design without depth, text-heavy pages (currently triggered by `disclaimerPage.dart` and `phone.dart` header copy).

--- a/docs/adr/ADR-005-resolve-ux-gaps.md
+++ b/docs/adr/ADR-005-resolve-ux-gaps.md
@@ -1,0 +1,60 @@
+# ADR-005: Resolve UX Gaps Identified in UX_GAPS Audit
+
+- **Status**: proposed
+- **Date**: 2026-05-24
+- **Deciders**: <leave blank for author to fill>
+- **Tags**: ux, accessibility, rtl, theming, crisis-safety, mental-health
+
+## Context
+
+A static UX audit of `lib/` was completed on 2026-05-24 and recorded in [`docs/UX_GAPS.md`](../UX_GAPS.md). The audit catalogues UX gaps across the Mazilon Flutter mental-health app (Hebrew/English, iOS + Android + Web) with `file:line` evidence and a four-tier severity scale:
+
+| Sev | Meaning |
+|-----|---------|
+| **S0** | Blocks a crisis-time task or risks user harm (silent failure on emergency call, trapped flow) |
+| **S1** | Accessibility / safety regression for vulnerable users (touch targets, screen readers, locale) |
+| **S2** | Visible polish / correctness gap that erodes trust |
+| **S3** | Inconsistency or maintainability issue with downstream UX cost |
+
+The audit surfaces two **S0** findings on the crisis path (`UX_GAPS.md` §2.1, §2.2), several **S1** accessibility/RTL findings spread across the home → plan → phone routes, and a long tail of **S2/S3** polish and theming items. The Phase-10 test-coverage work (ADR-001 → ADR-004) closed the test-infrastructure gaps; ADR-005 picks up the parallel UX track.
+
+**Why decide now:**
+
+- The S0 findings are user-safety issues on a mental-health app. `launchUrl` failures during a dial attempt are currently silent (`lib/util/Phone/phoneTextAndIcon.dart:39-43`); the SOS FAB and bottom nav are both removed during full-screen video (`lib/menu.dart:289,320`). Both reach production with no telemetry or recovery affordance.
+- The S1 RTL and Semantics gaps compound: every new screen added without a `Directionality`-aware pattern and without `Semantics(label:)` adds to the remediation cost.
+- The codebase has no `ThemeData` and no semantic color tokens (`lib/util/styles.dart:5-13`, `lib/main.dart:410-428`). Each new feature adds another ad-hoc color/font choice; without a tokens decision, S2 polish work is duplicate effort.
+
+## Decision
+
+Adopt the five-phase remediation order proposed in `UX_GAPS.md` §4, with each phase scoped as a separate PR. The phases are ordered by user-impact (S0 first) and by structural unblock (theme tokens unblock the S2 polish work):
+
+1. **Phase A — Crisis path hardening (S0).** Wrap `launchUrl` and SMS/WhatsApp helpers in `lib/util/Phone/phoneTextAndIcon.dart` with explicit failure UI (snackbar + "Copy number" fallback + haptic). Keep the SOS FAB visible during full-screen video in `lib/menu.dart`. Surface the country-fallback condition in `lib/util/Phone/EmergencyPhones.dart:45-50`.
+2. **Phase B — Accessibility pass (S1).** Add `Semantics(label:)` / `tooltip:` to every icon-only control on the home → plan → phone route. Replace fixed `fontSize:` with `.sp` in the four hotspots listed in §1.7. Add `selected:` semantics to the bottom-nav buttons.
+3. **Phase C — RTL pass (S1).** Stop branching on `isRtl` for `textDirection` and padding. Lean on `Directionality.of(context)` and `EdgeInsetsDirectional` start/end. Fix the inverted `textDirection` in `lib/main_menu_dialog.dart:97-99`.
+4. **Phase D — Theme + tokens (S3, unlocks S2).** Define `ThemeData` (light + initially light-only `darkTheme` stub). Move the nine palette colors in `styles.dart:5-13` to a `ColorScheme`-backed token layer. Replace `Colors.red` destructive buttons (`myButtonStyle3`) with `colorScheme.error`.
+5. **Phase E — Loading / error contract (S2).** Introduce one shared async widget (loading / error-with-retry / empty / data) and route every `FutureBuilder` through it. Remove the unconditional "finished" toast in `personalPlanWidget.dart:127`.
+
+Each phase ships behind its own PR with a regression test where feasible. Phase A is the only phase blocked from being deferred — the others may be reordered post-A based on capacity.
+
+## Consequences
+
+### Positive
+- Closes the two S0 crisis-path gaps before the next release cuts.
+- Establishes a `Semantics` and `Directionality` discipline that future screens inherit.
+- A `ThemeData` definition removes the per-screen color drift and makes a future dark-mode PR feasible in one change rather than dozens.
+- Each phase is independently reviewable and revertible.
+
+### Negative
+- Phase D touches every page that reads from `lib/util/styles.dart`. The blast radius is large even though each call site change is small. Mitigation: keep the legacy top-level `Color` variables as forwarders to the new tokens during the migration window.
+- Phase A introduces user-visible error UI on a path that today fails silently. Some users may prefer the silent failure ("the call just didn't happen, I'll try again") to a visible error. We accept this tradeoff because silent failure on a crisis dialer is the higher harm.
+- The phase plan does not yet account for caption/transcript work on Wellness Tools videos (§3.9), which is a WCAG 1.2.x gap but requires content work outside the Flutter codebase.
+
+### Neutral
+- The audit is static-only. Some findings (e.g. `UserSettings.dart` locale-dropdown live re-render at §3.8) are flagged as "verify on device"; Phase B/C work will need device-time before merging.
+- Typography target in `UX_GAPS.md` §5 (Lora + Raleway) is a *reference*, not part of this ADR's decision. Replacing `Rubix` is out of scope until a design review confirms the swap.
+
+## Links
+
+- [docs/UX_GAPS.md](../UX_GAPS.md) — source audit, severity scale, evidence with `file:line`
+- ADR-001 — Phase 6 hybrid path (established the precedent of staging risky changes phase-by-phase)
+- ADR-004 — Phase 9 production-injection extension (precedent for narrowly-scoped production changes with explicit consequence accounting)

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -359,5 +359,24 @@
   "shareButtonText": "مشاركة",
   "contactUs": "تواصل معنا",
   "shareAppMessage": "هذا تطبيق LP (Living Positively). أستخدمه وأنصح به، ربما سيكون مفيدًا لك أيضًا.",
-  "locationDisclaimer": "{gender,select,male{يتم استخدام موقعك فقط لتخصيص أرقام SOS لبلدك.} female{يتم استخدام موقعكِ فقط لتخصيص أرقام SOS لبلدكِ.} other{يتم استخدام موقعك فقط لتخصيص أرقام SOS لبلدك.}}"
+  "locationDisclaimer": "{gender,select,male{يتم استخدام موقعك فقط لتخصيص أرقام SOS لبلدك.} female{يتم استخدام موقعكِ فقط لتخصيص أرقام SOS لبلدكِ.} other{يتم استخدام موقعك فقط لتخصيص أرقام SOS لبلدك.}}",
+  "callFailedMessage": "تعذّر فتح المتصل لـ {number}",
+  "@callFailedMessage": {
+    "placeholders": {
+      "number": {
+        "type": "String"
+      }
+    }
+  },
+  "couldNotOpenApp": "تعذّر فتح التطبيق",
+  "copyNumberAction": "نسخ الرقم",
+  "numberCopiedToast": "تم نسخ الرقم",
+  "emergencyCountryFallback": "تُعرض أرقام الطوارئ الافتراضية ({country}). قد لا تعمل من موقعك الحالي.",
+  "@emergencyCountryFallback": {
+    "placeholders": {
+      "country": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1572,5 +1572,35 @@
   "locationDisclaimer": "{gender,select,male{Your location is only used in order to tailor the SOS numbers to your country.} female{Your location is only used in order to tailor the SOS numbers to your country.} other{Your location is only used in order to tailor the SOS numbers to your country.}}",
   "@locationDisclaimer": {
     "description": ""
+  },
+  "callFailedMessage": "Couldn't open the dialer for {number}",
+  "@callFailedMessage": {
+    "description": "Snackbar shown when launching the system dialer fails",
+    "placeholders": {
+      "number": {
+        "type": "String"
+      }
+    }
+  },
+  "couldNotOpenApp": "Couldn't open the app",
+  "@couldNotOpenApp": {
+    "description": "Generic snackbar for WhatsApp/SMS/web launch failures"
+  },
+  "copyNumberAction": "Copy number",
+  "@copyNumberAction": {
+    "description": "Snackbar action label that copies the failed number to clipboard"
+  },
+  "numberCopiedToast": "Number copied",
+  "@numberCopiedToast": {
+    "description": "Confirmation toast after copying a phone number to clipboard"
+  },
+  "emergencyCountryFallback": "Showing default emergency numbers ({country}). They may not connect from your current location.",
+  "@emergencyCountryFallback": {
+    "description": "Banner shown when country detection fails and the grid falls back to the default country",
+    "placeholders": {
+      "country": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -396,5 +396,10 @@
   
     "shareEmergency": "שיתוף הודעה במקרה של משבר",
   "noPermissionAllowedText": "הרשאה לא ניתנה",
-"shareEmergencyMessage":"אני במצב לא טוב ויש לי צורך בעזרה.אשמח לעזרתך בהפעלת התוכנית האישית שלי. בתודה מראש."
+"shareEmergencyMessage":"אני במצב לא טוב ויש לי צורך בעזרה.אשמח לעזרתך בהפעלת התוכנית האישית שלי. בתודה מראש.",
+  "callFailedMessage": "לא ניתן לחייג את {number}",
+  "couldNotOpenApp": "לא ניתן לפתוח את האפליקציה",
+  "copyNumberAction": "העתק מספר",
+  "numberCopiedToast": "המספר הועתק",
+  "emergencyCountryFallback": "מוצגים מספרי חירום ברירת מחדל ({country}). ייתכן שלא יפעלו ממיקומך."
 } 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2067,6 +2067,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{gender,select,male{Your location is only used in order to tailor the SOS numbers to your country.} female{Your location is only used in order to tailor the SOS numbers to your country.} other{Your location is only used in order to tailor the SOS numbers to your country.}}'**
   String locationDisclaimer(String gender);
+
+  /// Message shown when a phone/dialer launch fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t open the dialer for {number}'**
+  String callFailedMessage(String number);
+
+  /// Message shown when a non-call app (WhatsApp, site, SMS) fails to open.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t open the app'**
+  String get couldNotOpenApp;
+
+  /// Label for the snackbar action that copies the phone number to clipboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy number'**
+  String get copyNumberAction;
+
+  /// Toast shown after the number is copied to clipboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Number copied'**
+  String get numberCopiedToast;
+
+  /// Banner shown when country detection fails and the emergency grid falls back to the default country.
+  ///
+  /// In en, this message translates to:
+  /// **'Showing default emergency numbers ({country}). They may not connect from your current location.'**
+  String emergencyCountryFallback(String country);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3890,4 +3890,20 @@ class AppLocalizationsAr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String callFailedMessage(String number) => 'تعذّر فتح المتصل لـ $number';
+
+  @override
+  String get couldNotOpenApp => 'تعذّر فتح التطبيق';
+
+  @override
+  String get copyNumberAction => 'نسخ الرقم';
+
+  @override
+  String get numberCopiedToast => 'تم نسخ الرقم';
+
+  @override
+  String emergencyCountryFallback(String country) =>
+      'تُعرض أرقام الطوارئ الافتراضية ($country). قد لا تعمل من موقعك الحالي.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3912,4 +3912,21 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String callFailedMessage(String number) =>
+      "Couldn't open the dialer for $number";
+
+  @override
+  String get couldNotOpenApp => "Couldn't open the app";
+
+  @override
+  String get copyNumberAction => 'Copy number';
+
+  @override
+  String get numberCopiedToast => 'Number copied';
+
+  @override
+  String emergencyCountryFallback(String country) =>
+      'Showing default emergency numbers ($country). They may not connect from your current location.';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3883,4 +3883,20 @@ class AppLocalizationsHe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String callFailedMessage(String number) => 'לא ניתן לחייג את $number';
+
+  @override
+  String get couldNotOpenApp => 'לא ניתן לפתוח את האפליקציה';
+
+  @override
+  String get copyNumberAction => 'העתק מספר';
+
+  @override
+  String get numberCopiedToast => 'המספר הועתק';
+
+  @override
+  String emergencyCountryFallback(String country) =>
+      'מוצגים מספרי חירום ברירת מחדל ($country). ייתכן שלא יפעלו ממיקומך הנוכחי.';
 }

--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -285,14 +285,19 @@ class _MenuState extends LPExtendedState<Menu> {
         backgroundColor: appWhite,
         resizeToAvoidBottomInset: false,
         body: currentScreen,
-        //when full screen don't show the SOS button
-        floatingActionButton: isFullScreen
-            ? null
-            : FloatingActionButton(
-                shape: const CircleBorder(),
-                backgroundColor: const Color.fromARGB(255, 33, 1, 101),
-                foregroundColor: appWhite,
-                child: Column(
+        // SOS FAB is always visible — ADR-005 §A.2: emergency access must be
+        // reachable in every app state, including fullscreen video playback.
+        floatingActionButton: FloatingActionButton(
+          shape: const CircleBorder(),
+          backgroundColor: isFullScreen
+              ? const Color.fromARGB(200, 33, 1, 101) // ~78% opaque in fullscreen
+              : const Color.fromARGB(255, 33, 1, 101),
+          foregroundColor: appWhite,
+          mini: isFullScreen,
+          tooltip: 'SOS', // announces to TalkBack/VoiceOver
+          child: isFullScreen
+              ? const Icon(Icons.phone)
+              : Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
                     const Icon(Icons.phone),
@@ -307,15 +312,19 @@ class _MenuState extends LPExtendedState<Menu> {
                         20),
                   ],
                 ),
-                onPressed: () {
-                  setState(() {
-                    currentScreen =
-                        PhonePage(phonePageData: widget.phonePageData);
-                    current = PagesCode.EmergencyPhones;
-                  });
-                },
-              ),
-        floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+          onPressed: () {
+            setState(() {
+              currentScreen =
+                  PhonePage(phonePageData: widget.phonePageData);
+              current = PagesCode.EmergencyPhones;
+              // Exit fullscreen so emergency page renders with full chrome
+              isFullScreen = false;
+            });
+          },
+        ),
+        floatingActionButtonLocation: isFullScreen
+            ? FloatingActionButtonLocation.endFloat
+            : FloatingActionButtonLocation.centerDocked,
         //when full screen don't show the bottom navigation bar
         bottomNavigationBar: isFullScreen
             ? null

--- a/lib/util/Phone/EmergencyPhones.dart
+++ b/lib/util/Phone/EmergencyPhones.dart
@@ -48,12 +48,50 @@ class EmergencyPhonesGrid extends StatelessWidget {
           'No emergency mapping for countryCode="$countryCode". Using default "${defaultEmergencyCountry.id}".');
     }
     final activeCountry = country ?? defaultEmergencyCountry;
+    final bool isFallback = country == null;
     final localNumbers = activeCountry.emergencyNumbers;
     final appLocale = AppLocalizations.of(context);
     final displayedNumbers =
         appLocale?.localeName == 'he' && activeCountry.id == 'israel'
             ? _hebrewIsraelEmergencyOrder(localNumbers)
             : localNumbers;
+
+    Widget? fallbackBanner;
+    if (isFallback) {
+      final localizedCountry = activeCountry.id;
+      fallbackBanner = Semantics(
+        liveRegion: true,
+        container: true,
+        child: Container(
+          margin: const EdgeInsets.fromLTRB(0, 0, 0, 8),
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: const Color(0xFFFFF4E5),
+            border: Border.all(color: const Color(0xFFE0A82E), width: 1),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Icon(Icons.info_outline,
+                  color: Color(0xFFB76E00), size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  appLocale?.emergencyCountryFallback(localizedCountry) ??
+                      'Showing default emergency numbers ($localizedCountry). They may not connect from your current location.',
+                  style: const TextStyle(
+                    color: Color(0xFF7A4B00),
+                    fontSize: 13,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: LayoutBuilder(
@@ -64,7 +102,7 @@ class EmergencyPhonesGrid extends StatelessWidget {
               (constraints.maxWidth - spacing * (crossAxisCount - 1)) /
                   crossAxisCount;
 
-          return Wrap(
+          final grid = Wrap(
             spacing: spacing,
             runSpacing: spacing,
             children: [
@@ -77,6 +115,15 @@ class EmergencyPhonesGrid extends StatelessWidget {
                   ),
                 ),
             ],
+          );
+
+          if (fallbackBanner == null) {
+            return grid;
+          }
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [fallbackBanner, grid],
           );
         },
       ),

--- a/lib/util/Phone/emergencyDialogBox.dart
+++ b/lib/util/Phone/emergencyDialogBox.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: avoid_print
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:mazilon/util/Phone/phoneTextAndIcon.dart';
 import 'package:mazilon/util/styles.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -65,7 +64,7 @@ class EmergencyDialogBox extends StatelessWidget {
                       final locale = AppLocalizations.of(context);
                       final ok = await dialPhone(number);
                       if (!ok) {
-                        _showLaunchFailureSnackBar(
+                        showLaunchFailureSnackBar(
                           messenger,
                           locale,
                           number,
@@ -87,7 +86,7 @@ class EmergencyDialogBox extends StatelessWidget {
                         body: textMessage,
                       );
                       if (!ok) {
-                        _showLaunchFailureSnackBar(
+                        showLaunchFailureSnackBar(
                           messenger,
                           locale,
                           textNumber,
@@ -104,7 +103,7 @@ class EmergencyDialogBox extends StatelessWidget {
                     final locale = AppLocalizations.of(context);
                     final ok = await openWhatsApp(whatsappNumber);
                     if (!ok) {
-                      _showLaunchFailureSnackBar(
+                      showLaunchFailureSnackBar(
                         messenger,
                         locale,
                         whatsappNumber,
@@ -122,7 +121,7 @@ class EmergencyDialogBox extends StatelessWidget {
                       final locale = AppLocalizations.of(context);
                       final ok = await openSite(link);
                       if (!ok) {
-                        _showLaunchFailureSnackBar(
+                        showLaunchFailureSnackBar(
                           messenger,
                           locale,
                           '',
@@ -155,40 +154,4 @@ class EmergencyDialogBox extends StatelessWidget {
       ],
     );
   }
-}
-
-/// Shows a snackbar outside the AlertDialog by using a pre-captured [messenger]
-/// and [appLocale] (captured before the async gap — strategy b from ADR-005 §A.1).
-void _showLaunchFailureSnackBar(
-  ScaffoldMessengerState? messenger,
-  AppLocalizations? appLocale,
-  String number, {
-  required bool isCallFailure,
-}) {
-  if (messenger == null || appLocale == null) return;
-  HapticFeedback.heavyImpact();
-  messenger.hideCurrentSnackBar();
-  messenger.showSnackBar(
-    SnackBar(
-      content: Text(
-        isCallFailure
-            ? appLocale.callFailedMessage(number)
-            : appLocale.couldNotOpenApp,
-      ),
-      action: number.isEmpty
-          ? null
-          : SnackBarAction(
-              label: appLocale.copyNumberAction,
-              onPressed: () async {
-                await Clipboard.setData(ClipboardData(text: number));
-                messenger.hideCurrentSnackBar();
-                messenger.showSnackBar(SnackBar(
-                  content: Text(appLocale.numberCopiedToast),
-                  duration: const Duration(seconds: 2),
-                ));
-              },
-            ),
-      duration: const Duration(seconds: 6),
-    ),
-  );
 }

--- a/lib/util/Phone/emergencyDialogBox.dart
+++ b/lib/util/Phone/emergencyDialogBox.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_print
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mazilon/util/Phone/phoneTextAndIcon.dart';
 import 'package:mazilon/util/styles.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -59,7 +60,18 @@ class EmergencyDialogBox extends StatelessWidget {
                   getTextIconWidget(
                     appLocale!.dialButton(gender),
                     () async {
-                      await dialPhone(number);
+                      // Capture messenger before await to avoid mounted/race issues (strategy b).
+                      final messenger = ScaffoldMessenger.maybeOf(context);
+                      final locale = AppLocalizations.of(context);
+                      final ok = await dialPhone(number);
+                      if (!ok) {
+                        _showLaunchFailureSnackBar(
+                          messenger,
+                          locale,
+                          number,
+                          isCallFailure: true,
+                        );
+                      }
                     },
                     Icons.phone,
                   ),
@@ -67,23 +79,56 @@ class EmergencyDialogBox extends StatelessWidget {
                   getTextIconWidget(
                     'Text',
                     () async {
-                      await openTextMessage(
+                      // Capture messenger before await to avoid mounted/race issues (strategy b).
+                      final messenger = ScaffoldMessenger.maybeOf(context);
+                      final locale = AppLocalizations.of(context);
+                      final ok = await openTextMessage(
                         textNumber,
                         body: textMessage,
                       );
+                      if (!ok) {
+                        _showLaunchFailureSnackBar(
+                          messenger,
+                          locale,
+                          textNumber,
+                          isCallFailure: false,
+                        );
+                      }
                     },
                     Icons.sms,
                   ),
                 if (hasWhatsApp)
                   getTextIconWidget(appLocale!.whatsApp, () async {
-                    await openWhatsApp(whatsappNumber);
+                    // Capture messenger before await to avoid mounted/race issues (strategy b).
+                    final messenger = ScaffoldMessenger.maybeOf(context);
+                    final locale = AppLocalizations.of(context);
+                    final ok = await openWhatsApp(whatsappNumber);
+                    if (!ok) {
+                      _showLaunchFailureSnackBar(
+                        messenger,
+                        locale,
+                        whatsappNumber,
+                        isCallFailure: false,
+                      );
+                    }
                   }, Icons.chat),
 
                 if (hasLink)
                   getTextIconWidget(
                     isChatLink ? 'Chat' : appLocale.link,
                     () async {
-                      await openSite(link);
+                      // Capture messenger before await to avoid mounted/race issues (strategy b).
+                      final messenger = ScaffoldMessenger.maybeOf(context);
+                      final locale = AppLocalizations.of(context);
+                      final ok = await openSite(link);
+                      if (!ok) {
+                        _showLaunchFailureSnackBar(
+                          messenger,
+                          locale,
+                          '',
+                          isCallFailure: false,
+                        );
+                      }
                     },
                     isChatLink ? Icons.chat_bubble_outline : Icons.language,
                   ),
@@ -110,4 +155,40 @@ class EmergencyDialogBox extends StatelessWidget {
       ],
     );
   }
+}
+
+/// Shows a snackbar outside the AlertDialog by using a pre-captured [messenger]
+/// and [appLocale] (captured before the async gap — strategy b from ADR-005 §A.1).
+void _showLaunchFailureSnackBar(
+  ScaffoldMessengerState? messenger,
+  AppLocalizations? appLocale,
+  String number, {
+  required bool isCallFailure,
+}) {
+  if (messenger == null || appLocale == null) return;
+  HapticFeedback.heavyImpact();
+  messenger.hideCurrentSnackBar();
+  messenger.showSnackBar(
+    SnackBar(
+      content: Text(
+        isCallFailure
+            ? appLocale.callFailedMessage(number)
+            : appLocale.couldNotOpenApp,
+      ),
+      action: number.isEmpty
+          ? null
+          : SnackBarAction(
+              label: appLocale.copyNumberAction,
+              onPressed: () async {
+                await Clipboard.setData(ClipboardData(text: number));
+                messenger.hideCurrentSnackBar();
+                messenger.showSnackBar(SnackBar(
+                  content: Text(appLocale.numberCopiedToast),
+                  duration: const Duration(seconds: 2),
+                ));
+              },
+            ),
+      duration: const Duration(seconds: 6),
+    ),
+  );
 }

--- a/lib/util/Phone/emergencyDialogBox.dart
+++ b/lib/util/Phone/emergencyDialogBox.dart
@@ -58,77 +58,48 @@ class EmergencyDialogBox extends StatelessWidget {
                 if (canCall)
                   getTextIconWidget(
                     appLocale!.dialButton(gender),
-                    () async {
-                      // Capture messenger before await to avoid mounted/race issues (strategy b).
-                      final messenger = ScaffoldMessenger.maybeOf(context);
-                      final locale = AppLocalizations.of(context);
-                      final ok = await dialPhone(number);
-                      if (!ok) {
-                        showLaunchFailureSnackBar(
-                          messenger,
-                          locale,
-                          number,
-                          isCallFailure: true,
-                        );
-                      }
-                    },
+                    () => launchWithFeedback(
+                      context,
+                      number,
+                      isCallFailure: true,
+                      launch: () => dialPhone(number),
+                    ),
                     Icons.phone,
                   ),
                 if (hasText)
                   getTextIconWidget(
                     'Text',
-                    () async {
-                      // Capture messenger before await to avoid mounted/race issues (strategy b).
-                      final messenger = ScaffoldMessenger.maybeOf(context);
-                      final locale = AppLocalizations.of(context);
-                      final ok = await openTextMessage(
+                    () => launchWithFeedback(
+                      context,
+                      textNumber,
+                      isCallFailure: false,
+                      launch: () => openTextMessage(
                         textNumber,
                         body: textMessage,
-                      );
-                      if (!ok) {
-                        showLaunchFailureSnackBar(
-                          messenger,
-                          locale,
-                          textNumber,
-                          isCallFailure: false,
-                        );
-                      }
-                    },
+                      ),
+                    ),
                     Icons.sms,
                   ),
                 if (hasWhatsApp)
-                  getTextIconWidget(appLocale!.whatsApp, () async {
-                    // Capture messenger before await to avoid mounted/race issues (strategy b).
-                    final messenger = ScaffoldMessenger.maybeOf(context);
-                    final locale = AppLocalizations.of(context);
-                    final ok = await openWhatsApp(whatsappNumber);
-                    if (!ok) {
-                      showLaunchFailureSnackBar(
-                        messenger,
-                        locale,
-                        whatsappNumber,
-                        isCallFailure: false,
-                      );
-                    }
-                  }, Icons.chat),
-
+                  getTextIconWidget(
+                    appLocale!.whatsApp,
+                    () => launchWithFeedback(
+                      context,
+                      whatsappNumber,
+                      isCallFailure: false,
+                      launch: () => openWhatsApp(whatsappNumber),
+                    ),
+                    Icons.chat,
+                  ),
                 if (hasLink)
                   getTextIconWidget(
                     isChatLink ? 'Chat' : appLocale.link,
-                    () async {
-                      // Capture messenger before await to avoid mounted/race issues (strategy b).
-                      final messenger = ScaffoldMessenger.maybeOf(context);
-                      final locale = AppLocalizations.of(context);
-                      final ok = await openSite(link);
-                      if (!ok) {
-                        showLaunchFailureSnackBar(
-                          messenger,
-                          locale,
-                          '',
-                          isCallFailure: false,
-                        );
-                      }
-                    },
+                    () => launchWithFeedback(
+                      context,
+                      '',
+                      isCallFailure: false,
+                      launch: () => openSite(link),
+                    ),
                     isChatLink ? Icons.chat_bubble_outline : Icons.language,
                   ),
 

--- a/lib/util/Phone/phoneTextAndIcon.dart
+++ b/lib/util/Phone/phoneTextAndIcon.dart
@@ -52,6 +52,11 @@ Widget phoneContact(String phone, String contact) {
 /// reach for a stale context after an `await` (the bug that motivated
 /// ADR-005 §A.1).
 ///
+/// "Failure" covers both a `false` return value AND a thrown exception
+/// (e.g. `PlatformException` for unsupported schemes, `ArgumentError`
+/// for malformed URIs) from `url_launcher` — both paths reach the user
+/// as the same recoverable snackbar.
+///
 /// [number] is the value offered to the snackbar's "Copy number" action;
 /// pass an empty string for launches that have no number worth copying
 /// (e.g. opening a web link).
@@ -63,7 +68,13 @@ Future<void> launchWithFeedback(
 }) async {
   final messenger = ScaffoldMessenger.maybeOf(context);
   final locale = AppLocalizations.of(context);
-  final ok = await launch();
+  bool ok;
+  try {
+    ok = await launch();
+  } catch (error, stackTrace) {
+    debugPrint('launchWithFeedback caught $error\n$stackTrace');
+    ok = false;
+  }
   if (!ok) {
     showLaunchFailureSnackBar(
       messenger,

--- a/lib/util/Phone/phoneTextAndIcon.dart
+++ b/lib/util/Phone/phoneTextAndIcon.dart
@@ -1,22 +1,40 @@
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
 import 'package:mazilon/util/styles.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 Widget phoneContact(String phone, String contact) {
   return Row(
     children: <Widget>[
-      InkWell(
-        onTap: () async {
-          await dialPhone(phone);
-        },
-        child: CircleAvatar(
-          radius: 20, // adjust as needed
-          backgroundColor: primaryPurple,
-          foregroundColor: appWhite,
-          child: const Icon(Icons.phone, size: 20), // adjust as needed
+      // Builder gives us a context that's inside the surrounding Scaffold's
+      // subtree, so ScaffoldMessenger.maybeOf works in the tap callback.
+      Builder(
+        builder: (innerContext) => InkWell(
+          onTap: () async {
+            // Capture messenger + locale BEFORE the await to avoid mounted/race
+            // (same strategy as emergencyDialogBox.dart per ADR-005 §A.1).
+            final messenger = ScaffoldMessenger.maybeOf(innerContext);
+            final locale = AppLocalizations.of(innerContext);
+            final ok = await dialPhone(phone);
+            if (!ok) {
+              showLaunchFailureSnackBar(
+                messenger,
+                locale,
+                phone,
+                isCallFailure: true,
+              );
+            }
+          },
+          child: CircleAvatar(
+            radius: 20, // adjust as needed
+            backgroundColor: primaryPurple,
+            foregroundColor: appWhite,
+            child: const Icon(Icons.phone, size: 20), // adjust as needed
+          ),
         ),
       ),
       const SizedBox(width: 10.0), // adjust as needed
@@ -33,6 +51,47 @@ Widget phoneContact(String phone, String contact) {
         ),
       ),
     ],
+  );
+}
+
+/// Shows a snackbar describing a [launchUrl] failure, with an optional
+/// "Copy number" action that writes [number] to the clipboard. The
+/// [messenger] and [appLocale] must be captured before the async gap so we
+/// avoid the `context.mounted` race after a dialog closes.
+///
+/// Used by both [phoneContact] (personal emergency contacts) and
+/// `EmergencyDialogBox` (system emergency numbers). See ADR-005 §A.1.
+void showLaunchFailureSnackBar(
+  ScaffoldMessengerState? messenger,
+  AppLocalizations? appLocale,
+  String number, {
+  required bool isCallFailure,
+}) {
+  if (messenger == null || appLocale == null) return;
+  HapticFeedback.heavyImpact();
+  messenger.hideCurrentSnackBar();
+  messenger.showSnackBar(
+    SnackBar(
+      content: Text(
+        isCallFailure
+            ? appLocale.callFailedMessage(number)
+            : appLocale.couldNotOpenApp,
+      ),
+      action: number.isEmpty
+          ? null
+          : SnackBarAction(
+              label: appLocale.copyNumberAction,
+              onPressed: () async {
+                await Clipboard.setData(ClipboardData(text: number));
+                messenger.hideCurrentSnackBar();
+                messenger.showSnackBar(SnackBar(
+                  content: Text(appLocale.numberCopiedToast),
+                  duration: const Duration(seconds: 2),
+                ));
+              },
+            ),
+      duration: const Duration(seconds: 6),
+    ),
   );
 }
 

--- a/lib/util/Phone/phoneTextAndIcon.dart
+++ b/lib/util/Phone/phoneTextAndIcon.dart
@@ -14,21 +14,12 @@ Widget phoneContact(String phone, String contact) {
       // subtree, so ScaffoldMessenger.maybeOf works in the tap callback.
       Builder(
         builder: (innerContext) => InkWell(
-          onTap: () async {
-            // Capture messenger + locale BEFORE the await to avoid mounted/race
-            // (same strategy as emergencyDialogBox.dart per ADR-005 §A.1).
-            final messenger = ScaffoldMessenger.maybeOf(innerContext);
-            final locale = AppLocalizations.of(innerContext);
-            final ok = await dialPhone(phone);
-            if (!ok) {
-              showLaunchFailureSnackBar(
-                messenger,
-                locale,
-                phone,
-                isCallFailure: true,
-              );
-            }
-          },
+          onTap: () => launchWithFeedback(
+            innerContext,
+            phone,
+            isCallFailure: true,
+            launch: () => dialPhone(phone),
+          ),
           child: CircleAvatar(
             radius: 20, // adjust as needed
             backgroundColor: primaryPurple,
@@ -52,6 +43,35 @@ Widget phoneContact(String phone, String contact) {
       ),
     ],
   );
+}
+
+/// Captures `ScaffoldMessenger` and `AppLocalizations` from [context]
+/// *before* awaiting [launch], then routes a failed launch to
+/// [showLaunchFailureSnackBar]. Centralizing the capture-before-await
+/// pattern keeps the invariant in one place — callers can't accidentally
+/// reach for a stale context after an `await` (the bug that motivated
+/// ADR-005 §A.1).
+///
+/// [number] is the value offered to the snackbar's "Copy number" action;
+/// pass an empty string for launches that have no number worth copying
+/// (e.g. opening a web link).
+Future<void> launchWithFeedback(
+  BuildContext context,
+  String number, {
+  required bool isCallFailure,
+  required Future<bool> Function() launch,
+}) async {
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  final locale = AppLocalizations.of(context);
+  final ok = await launch();
+  if (!ok) {
+    showLaunchFailureSnackBar(
+      messenger,
+      locale,
+      number,
+      isCallFailure: isCallFailure,
+    );
+  }
 }
 
 /// Shows a snackbar describing a [launchUrl] failure, with an optional

--- a/lib/util/Phone/phoneTextAndIcon.dart
+++ b/lib/util/Phone/phoneTextAndIcon.dart
@@ -36,11 +36,13 @@ Widget phoneContact(String phone, String contact) {
   );
 }
 
-Future<void> dialPhone(String number) async {
+Future<bool> dialPhone(String number) async {
   final uri = _dialPhoneUri(number);
-  if (!await launchUrl(uri)) {
+  final launched = await launchUrl(uri);
+  if (!launched) {
     debugPrint('Could not launch $uri');
   }
+  return launched;
 }
 
 Uri _dialPhoneUri(String number) {
@@ -52,23 +54,25 @@ Uri _dialPhoneUri(String number) {
   return Uri.parse('tel:$trimmedNumber');
 }
 
-Future<void> openWhatsApp(String number) async {
+Future<bool> openWhatsApp(String number) async {
   final uri = Uri.parse('https://wa.me/$number');
   final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
   if (!launched) {
     debugPrint('Could not launch $uri');
   }
+  return launched;
 }
 
-Future<void> openSite(String url) async {
+Future<bool> openSite(String url) async {
   final uri = Uri.parse(url);
   final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
   if (!launched) {
     debugPrint('Could not launch $uri');
   }
+  return launched;
 }
 
-Future<void> openTextMessage(String number, {String body = ''}) async {
+Future<bool> openTextMessage(String number, {String body = ''}) async {
   final trimmedBody = body.trim();
   final uri = trimmedBody.isEmpty
       ? Uri(scheme: 'sms', path: number)
@@ -81,6 +85,7 @@ Future<void> openTextMessage(String number, {String body = ''}) async {
   if (!launched) {
     debugPrint('Could not launch $uri');
   }
+  return launched;
 }
 
 Widget getTextIconWidget(

--- a/lib/util/Phone/phoneTextAndIcon.dart
+++ b/lib/util/Phone/phoneTextAndIcon.dart
@@ -126,14 +126,27 @@ void showLaunchFailureSnackBar(
   );
 }
 
-Future<bool> dialPhone(String number) async {
-  final uri = _dialPhoneUri(number);
-  final launched = await launchUrl(uri);
+/// Wraps `launchUrl` so the four public action helpers share one
+/// "launch + log on false + return launched" shape.
+///
+/// [mode] is forwarded to `launchUrl`; pass `LaunchMode.externalApplication`
+/// for app handoffs (WhatsApp, browser). The default
+/// `LaunchMode.platformDefault` matches `launchUrl(uri)`'s historical
+/// behavior for `tel:` and `sms:`.
+Future<bool> _launchUriWithLogging(
+  Uri uri, {
+  LaunchMode mode = LaunchMode.platformDefault,
+}) async {
+  final launched = await launchUrl(uri, mode: mode);
   if (!launched) {
     debugPrint('Could not launch $uri');
   }
   return launched;
 }
+
+Future<bool> dialPhone(String number) => _launchUriWithLogging(
+      _dialPhoneUri(number),
+    );
 
 Uri _dialPhoneUri(String number) {
   final trimmedNumber = number.trim();
@@ -144,25 +157,17 @@ Uri _dialPhoneUri(String number) {
   return Uri.parse('tel:$trimmedNumber');
 }
 
-Future<bool> openWhatsApp(String number) async {
-  final uri = Uri.parse('https://wa.me/$number');
-  final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
-  if (!launched) {
-    debugPrint('Could not launch $uri');
-  }
-  return launched;
-}
+Future<bool> openWhatsApp(String number) => _launchUriWithLogging(
+      Uri.parse('https://wa.me/$number'),
+      mode: LaunchMode.externalApplication,
+    );
 
-Future<bool> openSite(String url) async {
-  final uri = Uri.parse(url);
-  final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
-  if (!launched) {
-    debugPrint('Could not launch $uri');
-  }
-  return launched;
-}
+Future<bool> openSite(String url) => _launchUriWithLogging(
+      Uri.parse(url),
+      mode: LaunchMode.externalApplication,
+    );
 
-Future<bool> openTextMessage(String number, {String body = ''}) async {
+Future<bool> openTextMessage(String number, {String body = ''}) {
   final trimmedBody = body.trim();
   final uri = trimmedBody.isEmpty
       ? Uri(scheme: 'sms', path: number)
@@ -171,11 +176,7 @@ Future<bool> openTextMessage(String number, {String body = ''}) async {
           path: number,
           queryParameters: {'body': trimmedBody},
         );
-  final launched = await launchUrl(uri);
-  if (!launched) {
-    debugPrint('Could not launch $uri');
-  }
-  return launched;
+  return _launchUriWithLogging(uri);
 }
 
 Widget getTextIconWidget(

--- a/test/Phone/launchFailureUI_test.dart
+++ b/test/Phone/launchFailureUI_test.dart
@@ -45,6 +45,38 @@ class _FailingUrlLauncherPlatform extends UrlLauncherPlatform {
   }
 }
 
+/// Throws on every launch — models the `PlatformException` / `ArgumentError`
+/// paths from `url_launcher` that can fire on unsupported schemes or
+/// malformed URIs.
+class _ThrowingUrlLauncherPlatform extends UrlLauncherPlatform {
+  String? lastLaunchedUrl;
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launch(
+    String url, {
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
+  }) async {
+    lastLaunchedUrl = url;
+    throw PlatformException(
+      code: 'CHANNEL-ERROR',
+      message:
+          'No Activity found to handle Intent { act=android.intent.action.DIAL }',
+    );
+  }
+}
+
 class _FakePersistentMemoryService implements PersistentMemoryService {
   @override
   Future<dynamic> getItem(String key, PersistentMemoryType type) async => null;
@@ -269,6 +301,68 @@ void main() {
       expect(find.byType(SnackBar), findsOneWidget);
       expect(find.text("Couldn't open the app"), findsOneWidget);
       expect(find.byType(SnackBarAction), findsNothing);
+    });
+  });
+
+  // url_launcher can throw (PlatformException / ArgumentError) in addition
+  // to returning false. launchWithFeedback must route both paths through
+  // the same snackbar so the user never sees a silent failure.
+  group('thrown launcher exceptions route through the snackbar', () {
+    testWidgets('phoneContact: dial that throws still shows snackbar',
+        (tester) async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _ThrowingUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      await tester.pumpWidget(
+        _wrapForPhoneContact((_) => phoneContact('555-9999', 'Therapist')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.phone));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fake.lastLaunchedUrl, 'tel:555-9999');
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(
+          find.text("Couldn't open the dialer for 555-9999"), findsOneWidget);
+      expect(
+          find.widgetWithText(SnackBarAction, 'Copy number'), findsOneWidget);
+    });
+
+    testWidgets(
+        'EmergencyDialogBox: WhatsApp that throws still shows the non-call snackbar',
+        (tester) async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _ThrowingUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      await tester.pumpWidget(
+        _wrapForEmergencyDialog(
+          const EmergencyDialogBox(
+            number: '',
+            whatsappNumber: '972501234567',
+            link: '',
+            hasWhatsApp: true,
+            hasLink: false,
+            canCall: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.chat));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fake.lastLaunchedUrl, 'https://wa.me/972501234567');
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.text("Couldn't open the app"), findsOneWidget);
+      expect(
+          find.widgetWithText(SnackBarAction, 'Copy number'), findsOneWidget);
     });
   });
 }

--- a/test/Phone/launchFailureUI_test.dart
+++ b/test/Phone/launchFailureUI_test.dart
@@ -1,0 +1,274 @@
+// Widget tests for the launch-failure UI introduced in ADR-005 §A.1.
+// Covers the path where `launchUrl` returns false from inside both
+// `phoneContact` (personal contacts) and `EmergencyDialogBox` (system
+// emergency numbers): a SnackBar with localized failure copy must render,
+// and a "Copy number" SnackBarAction must be present when there is a
+// number to copy.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mazilon/global_enums.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
+import 'package:mazilon/util/Phone/emergencyDialogBox.dart';
+import 'package:mazilon/util/Phone/phoneTextAndIcon.dart';
+import 'package:mazilon/util/appInformation.dart';
+import 'package:mazilon/util/persistent_memory_service.dart';
+import 'package:mazilon/util/userInformation.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class _FailingUrlLauncherPlatform extends UrlLauncherPlatform {
+  String? lastLaunchedUrl;
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launch(
+    String url, {
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
+  }) async {
+    lastLaunchedUrl = url;
+    return false;
+  }
+}
+
+class _FakePersistentMemoryService implements PersistentMemoryService {
+  @override
+  Future<dynamic> getItem(String key, PersistentMemoryType type) async => null;
+
+  @override
+  Future<void> reset() async {}
+
+  @override
+  Future<void> setItem(
+      String key, PersistentMemoryType type, dynamic value) async {}
+}
+
+Widget _wrapForPhoneContact(Widget Function(BuildContext) build) {
+  return MaterialApp(
+    supportedLocales: AppLocalizations.supportedLocales,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    locale: const Locale('en'),
+    home: ScreenUtilInit(
+      designSize: const Size(360, 690),
+      // Build inside ScreenUtilInit's builder so `.sp` works.
+      builder: (context, _) => Scaffold(body: Builder(builder: build)),
+    ),
+  );
+}
+
+Widget _wrapForEmergencyDialog(EmergencyDialogBox dialog) {
+  final userInfo = UserInformation(
+    gender: 'male',
+    service: _FakePersistentMemoryService(),
+  );
+  final appInfo = AppInformation();
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<UserInformation>.value(value: userInfo),
+      ChangeNotifierProvider<AppInformation>.value(value: appInfo),
+    ],
+    child: MaterialApp(
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      locale: const Locale('en'),
+      // Scaffold ancestor so the dialog's snackbar has a ScaffoldMessenger.
+      home: ScreenUtilInit(
+        designSize: const Size(360, 690),
+        builder: (_, __) => Scaffold(body: dialog),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('phoneContact failure UI', () {
+    testWidgets(
+        'on dial failure shows snackbar with localized message + Copy number action',
+        (tester) async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FailingUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      await tester.pumpWidget(
+        _wrapForPhoneContact((_) => phoneContact('555-1234', 'Mom')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.phone));
+      // The async dial completes on the next microtask; pump once for the
+      // SnackBar transition, then settle.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fake.lastLaunchedUrl, 'tel:555-1234');
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(
+          find.text("Couldn't open the dialer for 555-1234"), findsOneWidget);
+      expect(
+          find.widgetWithText(SnackBarAction, 'Copy number'), findsOneWidget);
+    });
+
+    testWidgets(
+        'tapping Copy number writes to clipboard and shows confirmation toast',
+        (tester) async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FailingUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      // Intercept Clipboard.setData so we don't need a platform channel.
+      String? clipboardWrite;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardWrite = (call.arguments as Map)['text'] as String?;
+        }
+        return null;
+      });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+
+      await tester.pumpWidget(
+        _wrapForPhoneContact((_) => phoneContact('555-7890', 'Crisis line')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.phone));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      // SnackBar floats below the visible viewport in test mode; tap by
+      // finder fails hit-testing. Invoke the action's onPressed callback
+      // directly — same code path, no gesture machinery.
+      final actionFinder = find.widgetWithText(SnackBarAction, 'Copy number');
+      expect(actionFinder, findsOneWidget);
+      final action = tester.widget<SnackBarAction>(actionFinder);
+      action.onPressed();
+      // Flush the async chain inside onPressed (Clipboard write + second
+      // showSnackBar) before asserting the follow-up toast renders.
+      await tester.pumpAndSettle();
+
+      expect(clipboardWrite, '555-7890');
+      expect(find.text('Number copied'), findsOneWidget);
+    });
+  });
+
+  group('EmergencyDialogBox failure UI', () {
+    testWidgets('dial failure surfaces the same snackbar as phoneContact',
+        (tester) async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FailingUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      await tester.pumpWidget(
+        _wrapForEmergencyDialog(
+          const EmergencyDialogBox(
+            number: '988',
+            whatsappNumber: '',
+            link: '',
+            hasWhatsApp: false,
+            hasLink: false,
+            canCall: true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.phone));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fake.lastLaunchedUrl, 'tel:988');
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.text("Couldn't open the dialer for 988"), findsOneWidget);
+      expect(
+          find.widgetWithText(SnackBarAction, 'Copy number'), findsOneWidget);
+    });
+
+    testWidgets(
+        'WhatsApp failure shows non-call message and still offers Copy number for the WhatsApp number',
+        (tester) async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FailingUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      await tester.pumpWidget(
+        _wrapForEmergencyDialog(
+          const EmergencyDialogBox(
+            number: '',
+            whatsappNumber: '972501234567',
+            link: '',
+            hasWhatsApp: true,
+            hasLink: false,
+            canCall: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.chat));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fake.lastLaunchedUrl, 'https://wa.me/972501234567');
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.text("Couldn't open the app"), findsOneWidget);
+      // WhatsApp uses the non-call message; Copy number IS still offered
+      // because the whatsappNumber is non-empty.
+      expect(
+          find.widgetWithText(SnackBarAction, 'Copy number'), findsOneWidget);
+    });
+
+    testWidgets('link failure has no Copy number action (no number to copy)',
+        (tester) async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FailingUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      await tester.pumpWidget(
+        _wrapForEmergencyDialog(
+          const EmergencyDialogBox(
+            number: '',
+            whatsappNumber: '',
+            link: 'https://example.com/help',
+            hasWhatsApp: false,
+            hasLink: true,
+            canCall: false,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.language));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(fake.lastLaunchedUrl, 'https://example.com/help');
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.text("Couldn't open the app"), findsOneWidget);
+      expect(find.byType(SnackBarAction), findsNothing);
+    });
+  });
+}

--- a/test/Phone/phoneTextAndIcon_test.dart
+++ b/test/Phone/phoneTextAndIcon_test.dart
@@ -104,13 +104,26 @@ void main() {
       expect(fake.lastLaunchedUrl, 'tel:1201');
     });
 
-    test('failed launch is handled silently (no throw)', () async {
+    test('failed launch returns false', () async {
       final originalPlatform = UrlLauncherPlatform.instance;
       final fake = _FakeUrlLauncherPlatform()..shouldSucceed = false;
       UrlLauncherPlatform.instance = fake;
       addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
 
-      await expectLater(dialPhone('555'), completes);
+      expect(await dialPhone('555'), isFalse);
+    });
+
+    test('successful launch returns true', () async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FakeUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() {
+        debugDefaultTargetPlatformOverride = null;
+        UrlLauncherPlatform.instance = originalPlatform;
+      });
+
+      expect(await dialPhone('1201'), isTrue);
     });
   });
 
@@ -125,13 +138,22 @@ void main() {
       expect(fake.lastLaunchedUrl, 'https://wa.me/972501234567');
     });
 
-    test('failure does not throw', () async {
+    test('failed launch returns false', () async {
       final originalPlatform = UrlLauncherPlatform.instance;
       final fake = _FakeUrlLauncherPlatform()..shouldSucceed = false;
       UrlLauncherPlatform.instance = fake;
       addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
 
-      await expectLater(openWhatsApp('1'), completes);
+      expect(await openWhatsApp('1'), isFalse);
+    });
+
+    test('successful launch returns true', () async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FakeUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      expect(await openWhatsApp('972501234567'), isTrue);
     });
   });
 
@@ -146,13 +168,22 @@ void main() {
       expect(fake.lastLaunchedUrl, 'https://example.com/help');
     });
 
-    test('failure does not throw', () async {
+    test('failed launch returns false', () async {
       final originalPlatform = UrlLauncherPlatform.instance;
       final fake = _FakeUrlLauncherPlatform()..shouldSucceed = false;
       UrlLauncherPlatform.instance = fake;
       addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
 
-      await expectLater(openSite('https://example.com'), completes);
+      expect(await openSite('https://example.com'), isFalse);
+    });
+
+    test('successful launch returns true', () async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FakeUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      expect(await openSite('https://example.com/help'), isTrue);
     });
   });
 
@@ -187,13 +218,22 @@ void main() {
       expect(fake.lastLaunchedUrl, 'sms:555');
     });
 
-    test('failure does not throw', () async {
+    test('failed launch returns false', () async {
       final originalPlatform = UrlLauncherPlatform.instance;
       final fake = _FakeUrlLauncherPlatform()..shouldSucceed = false;
       UrlLauncherPlatform.instance = fake;
       addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
 
-      await expectLater(openTextMessage('1', body: 'x'), completes);
+      expect(await openTextMessage('1', body: 'x'), isFalse);
+    });
+
+    test('successful launch returns true', () async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fake = _FakeUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fake;
+      addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+      expect(await openTextMessage('741741', body: 'HOME'), isTrue);
     });
   });
 }


### PR DESCRIPTION
# User description
## Summary
- Phase A of ADR-005 ([docs/adr/ADR-005-resolve-ux-gaps.md](docs/adr/ADR-005-resolve-ux-gaps.md)) — addresses the two S0 findings from [docs/UX_GAPS.md](docs/UX_GAPS.md) §2.1 and §2.2 plus the S1 country-fallback gap at §2.3.
- `launchUrl` failures (dialer, WhatsApp, SMS, site) are no longer silent: helpers return `Future<bool>`, and both `phoneContact` (personal contacts on PhonePage) and `EmergencyDialogBox` (system emergency numbers) now show a `SnackBar` with localized copy, `HapticFeedback.heavyImpact()`, and a "Copy number" `SnackBarAction` that writes to clipboard and confirms with a follow-up toast.
- SOS FAB stays visible during fullscreen Wellness Tools video (mini variant, ~78% opaque, `endFloat` location); tapping it exits fullscreen and lands on PhonePage. `tooltip: 'SOS'` for TalkBack/VoiceOver.
- When emergency-number country detection falls back to `defaultEmergencyCountry`, an amber `Semantics(liveRegion: true)` banner renders above the grid explaining which country's numbers are shown and that they may not connect from the user's current location.

## Files changed
- `lib/util/Phone/phoneTextAndIcon.dart` — `dialPhone`/`openWhatsApp`/`openSite`/`openTextMessage` return `Future<bool>`; `phoneContact` wires the snackbar UI via a `Builder`; public `showLaunchFailureSnackBar` helper used by both call sites.
- `lib/util/Phone/emergencyDialogBox.dart` — call sites capture `ScaffoldMessenger` + `AppLocalizations` before the `await` (strategy b, avoids `context.mounted` race), reuse the shared helper.
- `lib/menu.dart` — SOS FAB persistent across fullscreen.
- `lib/util/Phone/EmergencyPhones.dart` — country-fallback notice banner.
- `lib/l10n/app_{en,he,ar}.arb` + `app_localizations*.dart` — 5 new keys: `callFailedMessage`, `couldNotOpenApp`, `copyNumberAction`, `numberCopiedToast`, `emergencyCountryFallback`.
- `.gitignore` — adds `.claude-flow/` for local Ruflo swarm runtime state.

## Test plan
- [x] `flutter test` — 643 pass, 0 fail (+5 from new widget coverage)
- [x] `flutter analyze` — no new errors; 3 pre-existing `unnecessary_non_null_assertion` warnings on `appLocale!` patterns unchanged
- [x] `dart format --output=none --set-exit-if-changed` — clean
- [x] Unit: `test/Phone/phoneTextAndIcon_test.dart` — happy + failure return values for all 4 launch helpers
- [x] Widget: `test/Phone/launchFailureUI_test.dart` — 5 new tests driving `launchUrl == false` through `phoneContact` and `EmergencyDialogBox`, asserting `SnackBar`, localized copy, `Copy number` action, and clipboard-write + confirmation-toast path
- [x] Existing: `test/emergency_whatsapp_test.dart` — verified `EmergencyPhonesGrid` layout regression (caught and fixed during verification — `Padding` kept as outer to preserve constraints; banner-vs-no-banner branch inside `LayoutBuilder`)
- [x] Existing: `test/l10n/arabic_catalog_coverage_test.dart` — `@callFailedMessage` and `@emergencyCountryFallback` placeholder metadata added to `app_ar.arb`
- [ ] Manual: verify on device that SOS FAB taps land on PhonePage from a fullscreen video (no fullscreen video available in widget tests)

## ADR
Implements **Phase A only** of ADR-005. Phases B (Semantics + font-scale S1 pass), C (RTL `Directionality`), D (`ThemeData`/`ColorScheme`), and E (shared async loading/error contract) are still queued and will land as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Strengthen the crisis launch helpers (<code>phoneTextAndIcon</code>, <code>EmergencyDialogBox</code>, and associated localization) by routing every <code>launchUrl</code> call through <code>launchWithFeedback</code> so failures surface localized snackbars, haptics, and clipboard copy actions while the new widget/unit tests guard the behaviors. Keep the emergency UX resilient by keeping the SOS FAB reachable during fullscreen playback, surfacing the fallback-country banner from <code>EmergencyPhones</code>, and recording ADR-005/UX_GAPS+tooling metadata updates for the phased remediation plan.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/269?tool=ast&topic=SOS+visibility>SOS visibility</a>
        </td><td>Maintain emergency access by keeping the SOS FAB visible—even if it switches to the mini/fullscreen variant when <code>isFullScreen</code>—and by rendering a Semantics-friendly banner in <code>EmergencyPhones</code> whenever the grid reverts to the default country so users know the numbers may not work.<details><summary>Modified files (2)</summary><ul><li>lib/menu.dart</li>
<li>lib/util/Phone/EmergencyPhones.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>UX S0 crisis path hard...</td><td>May 25, 2026</td></tr>
<tr><td>lubacareer@gmail.com</td><td>Fix PR 251 navigation ...</td><td>May 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/269?tool=ast&topic=UX+roadmap+docs>UX roadmap docs</a>
        </td><td>Document the broader intent of ADR-005’s phased UX remediation plan plus the underlying <code>docs/UX_GAPS.md</code> audit so reviewers understand why the crisis-path fixes are scoped as Phase A of the larger UX effort.<details><summary>Modified files (2)</summary><ul><li>docs/UX_GAPS.md</li>
<li>docs/adr/ADR-005-resolve-ux-gaps.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>UX S0 crisis path hard...</td><td>May 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/269?tool=ast&topic=Crisis+launch+feedback>Crisis launch feedback</a>
        </td><td>Wrap every dial/WhatsApp/SMS/site action in <code>launchWithFeedback</code> so <code>phoneContact</code> and <code>EmergencyDialogBox</code> capture messenger/localization context before awaiting, emit the new localized <code>callFailedMessage</code>/<code>couldNotOpenApp</code> snackbars with haptic + copy-number affordances, and rely on the expanded l10n contract plus unit/widget coverage to guard both success and failure paths.<details><summary>Modified files (11)</summary><ul><li>lib/l10n/app_ar.arb</li>
<li>lib/l10n/app_en.arb</li>
<li>lib/l10n/app_he.arb</li>
<li>lib/l10n/app_localizations.dart</li>
<li>lib/l10n/app_localizations_ar.dart</li>
<li>lib/l10n/app_localizations_en.dart</li>
<li>lib/l10n/app_localizations_he.dart</li>
<li>lib/util/Phone/emergencyDialogBox.dart</li>
<li>lib/util/Phone/phoneTextAndIcon.dart</li>
<li>test/Phone/launchFailureUI_test.dart</li>
<li>test/Phone/phoneTextAndIcon_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>UX S0 crisis path hard...</td><td>May 25, 2026</td></tr>
<tr><td>dekel@tovli.co.il</td><td>Merge branch 'main' in...</td><td>May 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/269?tool=ast&topic=Tooling+metadata>Tooling metadata</a>
        </td><td>Track the new Claude/Swarm runtime metadata and prevent its artifacts from polluting commits by extending <code>.gitignore</code> alongside the new <code>.claude-flow</code>/swarm state files.<details><summary>Modified files (3)</summary><ul><li>.claude-flow/agents/store.json</li>
<li>.claude-flow/swarm/swarm-state.json</li>
<li>.gitignore</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>UX S0 crisis path: pho...</td><td>May 26, 2026</td></tr>
<tr><td>DavidAvigdor1996</td><td>Fix dependency w/ .env...</td><td>October 20, 2024</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/269?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>