### PR TITLE
Tests/phase101 2026

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,6 +214,105 @@ jobs:
           name: coverage-integration-lcov
           path: coverage/integration.info
 
+  integration-test-ios:
+    # Phase 10A (ADR-005 § A): per-file coverage gate for the iOS arms of
+    # NotificationsService. Runs on macos-14 + iOS simulator. macOS runners
+    # are free for public repositories under GitHub's open-source billing,
+    # so the ADR-002 / Round-9 macOS-cost framing that previously deferred
+    # iOS coverage no longer applies.
+    #
+    # Decoupled from build-android / integration-test: emulator- or
+    # simulator-class flakes here cannot pull the unit pipeline's 85%
+    # global floor below threshold. Sibling per-file gate
+    # (scripts/check_ios_integration_coverage.dart) enforces a 60% floor on
+    # lib/pages/notifications/notification_service.dart under the iOS
+    # invocation alone. The aggregate gate downstream merges this lcov with
+    # the unit + Android-integration lcovs and enforces the 90% combined
+    # floor.
+    runs-on: macos-14
+    env:
+      FIREBASE_OPTIONS_PATH: lib/util/Firebase/firebase_options.dart
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Export secrets as env vars
+        uses: oNaiPs/secrets-to-env-action@v1
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
+      - name: Write firebase options file
+        run: |
+          echo "$FIREBASE_OPTIONS" | base64 --decode > "${{ env.FIREBASE_OPTIONS_PATH }}"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.6"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: List available iOS simulators
+        # Diagnostic: surfaces the runtime + device names available on the
+        # macos-14 image. If the next step fails to find an iPhone, the
+        # output here is the first place to look.
+        run: xcrun simctl list devices available
+
+      - name: Boot iPhone simulator
+        # macos-14 images ship with multiple iPhone simulators (16, 15, 14)
+        # — pick the first "iPhone " device that is available. Avoid pinning
+        # to a specific model so the job survives when GitHub rotates the
+        # default Xcode/iOS-runtime bundle.
+        run: |
+          DEVICE_LINE=$(xcrun simctl list devices available | grep -E '^\s+iPhone ' | head -n 1)
+          DEVICE_ID=$(echo "$DEVICE_LINE" | awk -F '[()]' '{print $2}')
+          DEVICE_NAME=$(echo "$DEVICE_LINE" | sed -E 's/^\s+//; s/ \(.*//')
+          if [ -z "$DEVICE_ID" ]; then
+            echo "::error::No iPhone simulator found on this macos-14 runner."
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using simulator: $DEVICE_NAME ($DEVICE_ID)"
+          echo "DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
+          xcrun simctl boot "$DEVICE_ID"
+          # bootstatus blocks until the sim is fully booted (springboard up).
+          xcrun simctl bootstatus "$DEVICE_ID" -b
+
+      - name: Run iOS integration test
+        # Notes on the invocation below (mirrors the Android job's design
+        # rationale in the integration-test job above):
+        #
+        # 1. Single-line `flutter test` — no `\<newline>` continuations.
+        # 2. `-d "$DEVICE_ID"` explicitly targets the booted simulator. Without
+        #    `-d`, Flutter sometimes falls back to host-VM mode which
+        #    re-triggers "Integration tests and unit tests cannot be run in a
+        #    single invocation."
+        # 3. SENTRY_DSN dart-define is a synthetic test value — Sentry's
+        #    native SDK never reaches the network because the channel is
+        #    mocked inside the test setUp. Symmetric with the Android job.
+        # 4. We run ONLY `notifications_schedule_ios_test.dart` here, not the
+        #    whole `integration_test/` directory. The other integration tests
+        #    (bootstrap_smoke, wellness_player, logger_init,
+        #    notifications_schedule) are Android-targeted and have no value
+        #    on iOS. Running them on iOS would either pass tautologically
+        #    (because they use debugDefaultTargetPlatformOverride) or fail
+        #    due to Android-specific channel-mock assumptions.
+        run: |
+          flutter devices
+          flutter test integration_test/notifications_schedule_ios_test.dart --coverage --coverage-path coverage/integration_ios.info --dart-define=SENTRY_DSN=https://test@dsn.example.local/0 -d "$DEVICE_ID"
+
+      - name: Enforce iOS per-file coverage floor
+        run: dart run scripts/check_ios_integration_coverage.dart
+
+      - name: Upload iOS integration coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-integration-ios-lcov
+          path: coverage/integration_ios.info
+
   coverage-aggregate:
     # Phase 8 (ADR-003): aggregate coverage gate — merges unit lcov and
     # integration lcov, enforces 85% global floor on the union.
@@ -233,19 +332,22 @@ jobs:
     #   integration-test → check_integration_coverage.dart  (per-file floors)
     # This job is purely additive; removing it restores the Phase 7 state.
     runs-on: ubuntu-latest
-    needs: [build-android, integration-test]
+    needs: [build-android, integration-test, integration-test-ios]
     if: ${{ always() }}
     steps:
-      - name: Verify both upstream jobs succeeded
-        # Fail fast if either dependency did not succeed. We check the
+      - name: Verify all upstream jobs succeeded
+        # Fail fast if any dependency did not succeed. We check the
         # `result` outputs explicitly rather than relying on `needs:` to
         # skip — see job-level comment above for why a skipped required
-        # check is unsafe under branch protection.
+        # check is unsafe under branch protection. Phase 10A (ADR-005 § A)
+        # added integration-test-ios to the upstream set.
         run: |
           build_result="${{ needs.build-android.result }}"
           intg_result="${{ needs.integration-test.result }}"
-          echo "build-android result:    $build_result"
-          echo "integration-test result: $intg_result"
+          ios_result="${{ needs.integration-test-ios.result }}"
+          echo "build-android result:        $build_result"
+          echo "integration-test result:     $intg_result"
+          echo "integration-test-ios result: $ios_result"
           if [ "$build_result" != "success" ]; then
             echo "::error::Upstream job build-android did not succeed (result=$build_result); cannot compute aggregate coverage." >&2
             exit 1
@@ -254,7 +356,11 @@ jobs:
             echo "::error::Upstream job integration-test did not succeed (result=$intg_result); cannot compute aggregate coverage." >&2
             exit 1
           fi
-          echo "Both upstream jobs succeeded — proceeding with aggregate merge."
+          if [ "$ios_result" != "success" ]; then
+            echo "::error::Upstream job integration-test-ios did not succeed (result=$ios_result); cannot compute aggregate coverage." >&2
+            exit 1
+          fi
+          echo "All upstream jobs succeeded — proceeding with aggregate merge."
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -280,12 +386,23 @@ jobs:
           name: coverage-integration-lcov
           path: coverage
 
-      - name: Merge unit and integration lcov files
-        # Merges coverage/lcov.info (unit) and coverage/integration.info (intg)
-        # into coverage/aggregate.info by taking the max hit-count per line —
-        # same semantics as the ADR-001 Phase-6 merge step.  Output path is
-        # distinct from both inputs so neither upstream gate is clobbered.
-        run: dart run scripts/merge_lcov.dart coverage/aggregate.info coverage/lcov.info coverage/integration.info
+      - name: Download iOS integration coverage artifact
+        # Phase 10A (ADR-005 § A): iOS integration lcov from the macos-14
+        # integration-test-ios job. Merged in below as a third input.
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-integration-ios-lcov
+          path: coverage
+
+      - name: Merge unit, Android-integration, and iOS-integration lcov files
+        # Merges coverage/lcov.info (unit), coverage/integration.info (Android
+        # intg), and coverage/integration_ios.info (iOS intg) into
+        # coverage/aggregate.info by taking the max hit-count per line — same
+        # semantics as the ADR-001 Phase-6 merge step. Output path is distinct
+        # from all inputs so no upstream gate is clobbered.
+        # `merge_lcov.dart` accepts N positional inputs (PR #266 cleanup);
+        # adding the iOS lcov needs no script change.
+        run: dart run scripts/merge_lcov.dart coverage/aggregate.info coverage/lcov.info coverage/integration.info coverage/integration_ios.info
 
       - name: Enforce aggregate coverage gate
         # check_aggregate_coverage.dart reads coverage/lcov.info AND

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,6 +313,82 @@ jobs:
           name: coverage-integration-ios-lcov
           path: coverage/integration_ios.info
 
+  unit-test-web-telemetry:
+    # Phase 10C (ADR-005 § C): TELEMETRY-ONLY web-test job — NOT YET A GATE.
+    #
+    # This job exists to surface the failure modes of running the unit
+    # suite under `flutter test --platform chrome`. Once those failures
+    # are triaged and the suite is green under Chrome, this job will be
+    # renamed to `unit-test-web`, lose `continue-on-error: true` and the
+    # `if: always()` upload, gain a real gate step (e.g. a
+    # `scripts/check_web_coverage.dart`), and be wired into the
+    # `coverage-aggregate` job's `needs:` list so its lcov merges into
+    # the aggregate floor.
+    #
+    # Until that flip happens, this job is **deliberately green-on-failure**:
+    #   1. `continue-on-error: true` on the test step makes a `flutter test`
+    #      crash report job-success.
+    #   2. The job is NOT in `coverage-aggregate`'s `needs:` list, so a
+    #      missing/empty `coverage/lcov.info` cannot block the aggregate.
+    #
+    # This is intentional. Adding web to the aggregate before the suite is
+    # green would either skip-on-failure (unsafe under branch protection)
+    # or block all PRs on web flakes. The job's value during this phase is
+    # the `coverage-web-lcov` artifact + the test-step log, both of which
+    # PR reviewers can inspect to file triage issues.
+    #
+    # Tracking issue: see § "Still deferred (post Phase 10)" in
+    # docs/coverage-status.md.
+    runs-on: ubuntu-latest
+    env:
+      FIREBASE_OPTIONS_PATH: lib/util/Firebase/firebase_options.dart
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Export secrets as env vars
+        uses: oNaiPs/secrets-to-env-action@v1
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
+      - name: Write firebase options file
+        run: |
+          echo "$FIREBASE_OPTIONS" | base64 --decode > "${{ env.FIREBASE_OPTIONS_PATH }}"
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.6"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run unit tests on Chrome (telemetry — failures do NOT fail this job)
+        # `--platform chrome` compiles the test/ suite via dart2js and runs
+        # under headless Chrome. SENTRY_DSN dart-define is the same synthetic
+        # value the other jobs use; the AnalyticsService dart-define-merge
+        # variant (Phase 6 / ADR-001) is NOT re-run here — that file is
+        # already covered by the Android unit job's lcov.
+        #
+        # `continue-on-error: true` is INTENTIONAL during the triage phase
+        # (see job-level comment). Do not remove it without also wiring
+        # this job into coverage-aggregate's needs: list and adding a real
+        # gate step below.
+        continue-on-error: true
+        run: |
+          flutter test --platform chrome --coverage --dart-define=SENTRY_DSN=https://test@dsn.example.local/0
+
+      - name: Upload web coverage report (telemetry — may be missing or stale)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-web-lcov
+          path: coverage/lcov.info
+          # Do not fail the upload if the file is missing (it will be when
+          # `flutter test --platform chrome` crashes before emitting lcov).
+          if-no-files-found: warn
+
   coverage-aggregate:
     # Phase 8 (ADR-003): aggregate coverage gate — merges unit lcov and
     # integration lcov, enforces 85% global floor on the union.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -481,13 +481,16 @@ jobs:
         run: dart run scripts/merge_lcov.dart coverage/aggregate.info coverage/lcov.info coverage/integration.info coverage/integration_ios.info
 
       - name: Enforce aggregate coverage gate
-        # check_aggregate_coverage.dart reads coverage/lcov.info AND
-        # coverage/integration.info directly (parseLcovInputs), applies the
-        # same exclude list as check_coverage.dart, and enforces the 89%
-        # aggregate global floor (originally 85% under ADR-003 Phase 8;
-        # ratcheted to 89% by ADR-004 Phase 9 after the firestore-injection
-        # extension in firebase_functions.dart pushed unit-only coverage to
-        # 89.33% — see docs/coverage-status.md § Round 9).
+        # check_aggregate_coverage.dart reads coverage/lcov.info,
+        # coverage/integration.info, AND coverage/integration_ios.info directly
+        # (parseLcovInputs), applies the same exclude list as
+        # check_coverage.dart, and enforces the 89% aggregate global floor
+        # (originally 85% under ADR-003 Phase 8; ratcheted to 89% by ADR-004
+        # Phase 9 after the firestore-injection extension in
+        # firebase_functions.dart pushed unit-only coverage to 89.33% — see
+        # docs/coverage-status.md § Round 9). The iOS lcov was added as a
+        # third input under ADR-005 § A (Phase 10A) without ratcheting the
+        # floor, since adding an input can only raise the union.
         run: dart run scripts/check_aggregate_coverage.dart
 
       - name: Upload aggregate coverage report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,7 +221,7 @@ jobs:
 
   integration-test-ios:
     # Phase 10A (ADR-005 § A): per-file coverage gate for the iOS arms of
-    # NotificationsService. Runs on macos-15 + iOS simulator so the job has
+    # NotificationsService. Runs on macos-26 + iOS simulator so the job has
     # Xcode 16 / iOS 18 SDK symbols required by flutter_contacts' iOS Contacts
     # limited-permission support. macOS runners are free for public repositories
     # under GitHub's open-source billing, so the ADR-002 / Round-9 macOS-cost
@@ -235,7 +235,7 @@ jobs:
     # invocation alone. The aggregate gate downstream merges this lcov with
     # the unit + Android-integration lcovs and enforces the 90% combined
     # floor.
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       FIREBASE_OPTIONS_PATH: lib/util/Firebase/firebase_options.dart
     steps:
@@ -262,12 +262,12 @@ jobs:
 
       - name: List available iOS simulators
         # Diagnostic: surfaces the runtime + device names available on the
-        # macos-15 image. If the next step fails to find an iPhone, the
+        # macos-26 image. If the next step fails to find an iPhone, the
         # output here is the first place to look.
         run: xcrun simctl list devices available
 
       - name: Boot iPhone simulator
-        # macos-15 images ship with multiple iPhone simulators.
+        # macos-26 images ship with multiple iPhone simulators.
         # — pick the first "iPhone " device that is available. Avoid pinning
         # to a specific model so the job survives when GitHub rotates the
         # default Xcode/iOS-runtime bundle.
@@ -276,7 +276,7 @@ jobs:
           DEVICE_ID=$(echo "$DEVICE_LINE" | awk -F '[()]' '{print $2}')
           DEVICE_NAME=$(echo "$DEVICE_LINE" | sed -E 's/^\s+//; s/ \(.*//')
           if [ -z "$DEVICE_ID" ]; then
-            echo "::error::No iPhone simulator found on this macos-15 runner."
+            echo "::error::No iPhone simulator found on this macos-26 runner."
             xcrun simctl list devices available
             exit 1
           fi
@@ -469,7 +469,7 @@ jobs:
           path: coverage
 
       - name: Download iOS integration coverage artifact
-        # Phase 10A (ADR-005 § A): iOS integration lcov from the macos-15
+        # Phase 10A (ADR-005 § A): iOS integration lcov from the macos-26
         # integration-test-ios job. Merged in below as a third input.
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,9 +200,14 @@ jobs:
           #    native SDK is channel-mocked in the test so no real network
           #    traffic leaves the runner (PR #266 review, baz-reviewer
           #    finding 1).
+          #
+          # 5. The iOS-only notifications_schedule_ios_test.dart is excluded
+          #    here. The macOS integration-test-ios job owns that file; running
+          #    the whole integration_test/ directory on Android mixes iOS
+          #    method-channel assumptions with the Android plugin stack.
           script: |
             flutter devices
-            flutter test integration_test --coverage --coverage-path coverage/integration.info --dart-define=SENTRY_DSN=https://test@dsn.example.local/0 -d emulator-5554
+            flutter test integration_test/custom_categories_e2e_test.dart integration_test/bootstrap_smoke_test.dart integration_test/bootstrap_full_test.dart integration_test/wellness_player_test.dart integration_test/logger_init_test.dart integration_test/notifications_schedule_test.dart --coverage --coverage-path coverage/integration.info --dart-define=SENTRY_DSN=https://test@dsn.example.local/0 -d emulator-5554
 
       - name: Enforce integration-test per-file coverage floors
         run: dart run scripts/check_integration_coverage.dart
@@ -216,10 +221,11 @@ jobs:
 
   integration-test-ios:
     # Phase 10A (ADR-005 § A): per-file coverage gate for the iOS arms of
-    # NotificationsService. Runs on macos-14 + iOS simulator. macOS runners
-    # are free for public repositories under GitHub's open-source billing,
-    # so the ADR-002 / Round-9 macOS-cost framing that previously deferred
-    # iOS coverage no longer applies.
+    # NotificationsService. Runs on macos-15 + iOS simulator so the job has
+    # Xcode 16 / iOS 18 SDK symbols required by flutter_contacts' iOS Contacts
+    # limited-permission support. macOS runners are free for public repositories
+    # under GitHub's open-source billing, so the ADR-002 / Round-9 macOS-cost
+    # framing that previously deferred iOS coverage no longer applies.
     #
     # Decoupled from build-android / integration-test: emulator- or
     # simulator-class flakes here cannot pull the unit pipeline's 85%
@@ -229,7 +235,7 @@ jobs:
     # invocation alone. The aggregate gate downstream merges this lcov with
     # the unit + Android-integration lcovs and enforces the 90% combined
     # floor.
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       FIREBASE_OPTIONS_PATH: lib/util/Firebase/firebase_options.dart
     steps:
@@ -256,12 +262,12 @@ jobs:
 
       - name: List available iOS simulators
         # Diagnostic: surfaces the runtime + device names available on the
-        # macos-14 image. If the next step fails to find an iPhone, the
+        # macos-15 image. If the next step fails to find an iPhone, the
         # output here is the first place to look.
         run: xcrun simctl list devices available
 
       - name: Boot iPhone simulator
-        # macos-14 images ship with multiple iPhone simulators (16, 15, 14)
+        # macos-15 images ship with multiple iPhone simulators.
         # — pick the first "iPhone " device that is available. Avoid pinning
         # to a specific model so the job survives when GitHub rotates the
         # default Xcode/iOS-runtime bundle.
@@ -270,7 +276,7 @@ jobs:
           DEVICE_ID=$(echo "$DEVICE_LINE" | awk -F '[()]' '{print $2}')
           DEVICE_NAME=$(echo "$DEVICE_LINE" | sed -E 's/^\s+//; s/ \(.*//')
           if [ -z "$DEVICE_ID" ]; then
-            echo "::error::No iPhone simulator found on this macos-14 runner."
+            echo "::error::No iPhone simulator found on this macos-15 runner."
             xcrun simctl list devices available
             exit 1
           fi
@@ -463,7 +469,7 @@ jobs:
           path: coverage
 
       - name: Download iOS integration coverage artifact
-        # Phase 10A (ADR-005 § A): iOS integration lcov from the macos-14
+        # Phase 10A (ADR-005 § A): iOS integration lcov from the macos-15
         # integration-test-ios job. Merged in below as a third input.
         uses: actions/download-artifact@v4
         with:

--- a/docs/adr/ADR-005-phase-10-macos-runner-ios-and-web-coverage.md
+++ b/docs/adr/ADR-005-phase-10-macos-runner-ios-and-web-coverage.md
@@ -1,0 +1,236 @@
+# ADR-005: Phase 10 — macOS-runner iOS coverage, `bootstrapApp()` extraction, and web test gate
+
+- **Status**: accepted
+- **Date**: 2026-05-25
+- **Deciders**:
+- **Tags**: coverage, ci, ios, web, refactor
+
+## Context
+
+The Mazilon coverage initiative reached 89.29% unit / ~91.83% aggregate after
+Round 9 (see `docs/coverage-status.md` § Round 9 and ADR-004). The
+still-deferred table in Round 9 lists six items; three of them share a single
+root cause that this ADR addresses, and one new gap was identified during the
+Phase 10 plan validation that the prior ADRs never covered.
+
+### The macOS-runner cost framing changed
+
+ADR-002 § "Out of scope for Phase 7" and Round 9 § "Still deferred" both
+explicitly excluded iOS-specific notification paths on the grounds that
+"macOS runner costs 10× Linux CI minutes; no iOS-specific bug has motivated
+it." That framing was correct under GitHub Actions' standard billing.
+
+The project is **open-source** and the GitHub org is (or can be) opted into
+the free macOS runner allotment for public repositories. Under that billing,
+the 10× cost framing no longer applies, which unblocks the iOS deferred
+items at zero ongoing cost. This ADR ratifies that change in framing and
+plans the work it enables.
+
+### `main.dart` bootstrap is still uncovered
+
+`lib/main.dart` reached ~59.3% in Round 7 via the `bootstrap_smoke_test.dart`
+integration test that pumps the `MyApp` widget directly. Lines 104-156
+(`main()` body + `initializeApp` + the synchronous `Firebase.initializeApp`
+call before `runApp`) remained uncovered because Round 7 deliberately did
+not extract a `bootstrapApp()` helper — ADR-002 hard rule #1 ("no production
+code changes") prohibited it without a new ADR.
+
+### Web ships to production with zero test gate
+
+`build-web` and `build-dev-web` jobs in `.github/workflows/main.yml` build
+and deploy the web target to Azure Storage on every push, but neither job
+runs `flutter test --platform chrome` or any other web-specific test step.
+This means a web-only regression (a `dart:html` vs `dart:io` divergence, a
+`kIsWeb` branch bug, a web-incompatible plugin call) ships to production
+without any CI signal. None of ADR-001 through ADR-004 noticed this gap;
+it surfaced during the Phase 10 plan validation against the workflow file.
+
+### What this ADR does **not** address
+
+- **`callbackDispatcher` (Workmanager background entry-point, `main.dart`
+  lines 42-89).** Foreground integration tests cannot trigger a background
+  `Workmanager().executeTask` callback. Requires Patrol's background task
+  driver or a custom harness — out of scope, will need a separate ADR with
+  motivation beyond coverage (e.g. "we need to confirm the periodic worker
+  actually fires after reboot").
+- **`firebase_functions.dart` `?? FirebaseFirestore.instance` fallback
+  right-hand-sides (43 lines).** Structurally unreachable under the
+  injection pattern from ADR-001 / ADR-004. Accept as dead lines under the
+  existing tier-1 50% floor (file is at 93.8%) or rewrite the helpers to
+  not use the fallback shape — separate refactor ADR.
+- **`logger_service.dart` lines 17-18 (empty-DSN if-branch) and 29-31
+  (outer catch swallowed by Sentry SDK).** ~5 lines, ~0.07 pt aggregate
+  impact. Documented as accepted risk; revisit only if Phase 10 lift
+  consumes the 3 pt headroom.
+
+## Decision
+
+Execute Phase 10 as **three sub-decisions, one per PR**, each ratchetting
+the aggregate floor by ≤1 pt:
+
+### Sub-decision A — iOS notification paths via macOS-14 runner
+
+Add a fourth CI job `integration-test-ios` parallel to the existing
+`integration-test` job:
+
+- `runs-on: macos-14` (free for public repos under GitHub's open-source
+  macOS runner allotment; first job run must confirm the org is opted in
+  before the gate is treated as required).
+- Boot an iOS Simulator via `xcrun simctl` (macos-14 ships with Xcode +
+  iOS Simulator pre-installed; no third-party action needed).
+- Run `flutter test integration_test --coverage --coverage-path
+  coverage/integration_ios.info -d "iPhone 15"
+  --dart-define=SENTRY_DSN=https://test@dsn.example.local/0`.
+- New test file `integration_test/notifications_schedule_ios_test.dart`
+  mirrors the existing Android `notifications_schedule_test.dart` but
+  exercises **iOS-specific branches** in
+  `lib/pages/notifications/notification_service.dart`:
+  `IOSFlutterLocalNotificationsPlugin.requestPermissions` happy + denied
+  paths, `DarwinInitializationSettings` permission flags, and the
+  `Platform.isIOS` arm of `supportsReminderSettings()`.
+- New gate script `scripts/check_ios_integration_coverage.dart` enforces
+  a single per-file floor:
+  `lib/pages/notifications/notification_service.dart` ≥ 75% under the iOS
+  invocation alone (will exceed 95% post-aggregate-merge with Android intg).
+- Aggregate-gate merge updated to accept a third lcov input
+  (`coverage-integration-ios-lcov` artifact). `scripts/merge_lcov.dart`
+  already accepts N positional args.
+
+**No production-code change.** The iOS plugin paths are reached purely by
+test code; channel mocks follow the same shape as
+`test/notifications/notification_service_initialize_test.dart`.
+
+### Sub-decision B — `bootstrapApp()` extraction (4th sanctioned production exception)
+
+Extract `Future<Widget> bootstrapApp({FirebaseApp? firebaseApp,
+WorkmanagerPlatform? workmanager, SentryService? sentryService, ...})` from
+the current `main()` body. The helper does **everything `main()` does except
+`runApp`**. `main()` becomes a 2-line shim:
+
+```dart
+Future<void> main() async {
+  final app = await bootstrapApp();
+  runApp(app);
+}
+```
+
+This is the **fourth sanctioned production-code exception** to the coverage
+initiative's no-production-changes guard rail, alongside:
+
+1. ADR-001 Round 1 — `firestore` named-param injection on 14 helpers in
+   `firebase_functions.dart`.
+2. ADR-002 PR #266 — `@visibleForTesting NotificationsService.resetForTest()`.
+3. ADR-004 Round 9 — `firestore` named-param injection extended to 29 more
+   helpers in `firebase_functions.dart`.
+
+All four share the same shape: **narrow, mechanical, behaviour-preserving for
+production paths, necessary to reach a genuinely-unreachable test seam**.
+
+Test file `integration_test/bootstrap_full_test.dart` calls `bootstrapApp(...)`
+directly with fakes for the injectable parameters, asserts the returned
+widget tree, then pumps through the integration_test binding to drive
+lifecycle paths the existing `bootstrap_smoke_test.dart` only reached via
+the already-built `MyApp` instance.
+
+`scripts/check_integration_coverage.dart` gains a new per-file floor of 65%
+for `lib/main.dart`. `callbackDispatcher` (lines 42-89) stays uncovered —
+explicitly out of Phase 10B scope per § Context.
+
+### Sub-decision C — Web platform test gate
+
+Add a new CI job `unit-test-web`:
+
+- `runs-on: ubuntu-latest` (Chrome headless is available on Linux runners;
+  no macOS needed for this sub-decision).
+- Steps: checkout → flutter setup → `flutter pub get` →
+  `flutter test --platform chrome --coverage`.
+- Upload coverage as `coverage-web-lcov` artifact (distinct filename — does
+  NOT clobber the Android unit job's `coverage-lcov`).
+
+**Initial landing posture: `continue-on-error: true` on the test step.**
+Web-platform test execution will almost certainly fail in some files that
+mock Android-specific plugin channels (path_provider, workmanager). The
+first run's failure modes are triaged in PR review and filed as follow-up
+issues; once the suite is green under `--platform chrome`, flip the gate
+to strict and add the web lcov as a fourth input to
+`scripts/merge_lcov.dart` in the coverage-aggregate job.
+
+**No production-code change** unless triage uncovers an actual web bug —
+in which case the bug fix lands in its own PR, not as part of this ADR.
+
+### Aggregate floor ratchet
+
+| Step | Aggregate % (est) | Floor | Headroom |
+|---|---|---|---|
+| Round 9 baseline | 91.83% | 89% | 2.83 pt |
+| + Phase 10A (iOS notif, ~15 lines) | ~92.0% | 89% | 3.0 pt |
+| + Phase 10B (bootstrapApp, ~50 lines) | ~92.8% | **90%** | 2.8 pt |
+| + Phase 10C (web gate, est 0-10 lines) | ~92.9% | 90% | 2.9 pt |
+
+Aggregate floor ratchets from **89% → 90%** when Sub-decision B lands and
+the first three CI runs confirm the aggregate %. Per-tier and per-file
+floors in `scripts/check_coverage.dart` are unchanged.
+
+## Consequences
+
+### Positive
+
+- iOS-specific notification paths gain CI coverage for the first time —
+  closes the largest remaining cluster of deferred items from ADR-002 / ADR-004.
+- `main.dart` foreground bootstrap (currently ~60%) lifts to ~85% — closes
+  the largest deferred unit-side item left after Round 9.
+- Web target gains a CI test gate — closes a real production-risk gap that
+  prior ADRs missed.
+- All three sub-decisions follow established ADR-001 / ADR-002 patterns:
+  narrow production exceptions, per-file floor scripts, aggregate-gate
+  merge. No new infrastructure invented.
+- Open-source macOS runner billing is a permanent constraint shift, not a
+  one-off — future iOS-specific work (e.g. iOS-specific UI tests, iOS
+  share extension) can build on the Phase 10A runner setup.
+
+### Negative
+
+- macOS-14 runner cold start ~3-4 min + iOS sim boot ~60-90s pushes
+  Phase 10A's job time to ~6-8 min. The aggregate-coverage job blocks on
+  it, lengthening the critical path of a PR's CI to ~10-12 min.
+- `bootstrapApp()` extraction is the fourth production-code exception in
+  a coverage-driven initiative; each exception slightly weakens the
+  "no-production-changes" guard rail. The mitigation (narrow, mechanical,
+  behaviour-preserving, ADR-sanctioned) is the same pattern as the prior
+  three, but reviewers may push back on the cumulative drift. The
+  alternative — leaving `main.dart` at ~60% forever — was judged worse.
+- Web test job initial landing with `continue-on-error: true` is a known
+  CI smell: a gate that doesn't gate. Mitigated by the explicit triage
+  step in PR review and the commitment to flip strict once the suite is
+  green. Risk: that flip never happens if no-one prioritizes the triage.
+
+### Neutral
+
+- The coverage-aggregate job's merge now handles 3 (and eventually 4)
+  lcov inputs instead of 2. `scripts/merge_lcov.dart` already supports
+  this; no script changes needed for the merge itself.
+- The three sub-decisions can land in any order; recommended sequence
+  (10A → 10B → 10C) is by ROI, not technical dependency.
+- macOS-runner billing opt-in status is checked at first job run, not
+  at ADR-acceptance time. If the org is not opted in, Phase 10A is
+  blocked at PR-CI level and the ADR will be marked superseded / on hold
+  until billing is resolved.
+
+## Links
+
+- `docs/coverage-status.md` — Round 9 § "Still deferred" lists the items
+  Phase 10 closes.
+- `docs/coverage-phase10-plan.md` — full Phase 10 plan, including
+  validation against repo state, three PR sequence, tooling reuse notes,
+  and open questions.
+- `docs/adr/ADR-001-phase-6-test-coverage-integration-tests.md` —
+  established the `firestore` injection pattern that ADR-005 § B mirrors
+  for `bootstrapApp()`.
+- `docs/adr/ADR-002-phase-7-integration-tests-deferred-coverage.md` —
+  established the per-file gate script pattern that ADR-005 § A reuses
+  for iOS.
+- `docs/adr/ADR-003-phase-8-aggregate-coverage-gate.md` — established
+  the aggregate-gate merge pattern that ADR-005 extends to 3-4 inputs.
+- `docs/adr/ADR-004-phase-9-firestore-injection-extension-firebase-functions.md`
+  — most recent precedent for a production-code exception, parallel in
+  shape to ADR-005 § B.

--- a/docs/coverage-phase10-plan.md
+++ b/docs/coverage-phase10-plan.md
@@ -1,0 +1,276 @@
+# Phase 10 Coverage Plan
+
+Generated: 2026-05-24 — continuation of `docs/coverage-status.md` (Rounds 1–9)
+and the ADR-001 / ADR-002 / ADR-003 / ADR-004 sequence.
+
+This plan is anchored on the constraint **"macOS runners in GitHub Actions are
+free for this project (open source)."** Phases 1–9 explicitly deferred iOS-
+specific work because macOS minutes were assumed to be ~10× Linux cost; that
+assumption no longer applies, which unblocks the largest remaining cluster of
+deferred items. The app ships to **android, iOS, and web** — Phase 10 closes
+the iOS and web gates that prior phases left open.
+
+## Validation of the current state (vs `docs/coverage-status.md` § Round 9)
+
+| Claim in coverage-status.md | Validated against repo |
+|---|---|
+| Unit global filtered coverage 89.29% | ✅ `scripts/check_coverage.dart` line 73: `_globalThreshold = 85.0` w/ "~89.3% as of round 9 (ADR-004)" comment |
+| Aggregate floor 89% | ✅ `scripts/check_aggregate_coverage.dart` + `.github/workflows/main.yml` § coverage-aggregate |
+| 3 CI gate jobs | ✅ `build-android` / `integration-test` / `coverage-aggregate` all wired in `main.yml` |
+| 3 sanctioned `lib/` exceptions | ✅ firestore inject ×14 (R1), `@visibleForTesting resetForTest()` (R7), firestore inject ×29 (R9) |
+| 8 pre-existing skips untouched | ✅ 3 in `test/Thanks/Journal_test.dart`, 5 in `test/menu_test.dart` |
+| `tests/phase101-2026` is base for Phase 10 | ✅ branch at parity with `main@68108fa` |
+| Local edit to `docs/coverage-status.md` | ⚠ Post-correction numbers polish in § Aggregate-floor derivation; bundle with Phase 10 commits |
+
+**Real omission found:** the doc has zero discussion of **web-platform test
+coverage**. `build-web` / `build-dev-web` jobs only build & deploy — they never
+run `flutter test --platform chrome`. This is a genuine gate hole for a
+multi-platform app.
+
+## Remaining gap landscape (post Round 9)
+
+| Item | Approx LF uncovered | Reachable by | ADR? | Phase 10 disposition |
+|---|---|---|---|---|
+| iOS-specific notification paths in `lib/pages/notifications/notification_service.dart` | ~30 | macOS-runner integration job | Yes — ADR-005 § A | **Phase 10A** |
+| `main()` / `initializeApp()` / `callbackDispatcher` direct coverage in `lib/main.dart` | ~50 (foreground bootstrap only; background callbackDispatcher excluded) | Refactor → `bootstrapApp()` helper | Yes — ADR-005 § B (4th sanctioned production exception) | **Phase 10B** |
+| Web-platform branches across `kIsWeb` guards (`main_menu_dialog.dart`, `file_service.dart`, etc.) | unknown (0–10 likely) | New `unit-test-web` job: `flutter test --platform chrome --coverage` | Yes — ADR-005 § C | **Phase 10C** |
+| `lib/util/logger_service.dart` lines 17-18 (empty-DSN if-branch) | 2 | Dual-invocation pattern-2 of ADR-001 | No (low ROI) | **Decline** unless headroom shrinks |
+| `lib/util/logger_service.dart` lines 29-31 (outer catch, swallowed by Sentry SDK) | 3 | Runtime-readable `_sentryDsn` (production change) | No (low ROI) | **Decline** |
+| `callbackDispatcher` (Workmanager background entry-point), `lib/main.dart` lines 42-89 | ~45 | Patrol-style background harness | Yes — separate ADR, beyond coverage | **Hard skip** in Phase 10 |
+| `lib/util/Firebase/firebase_functions.dart` `?? FirebaseFirestore.instance` fallback right-hand-sides | ~43 (1 line × 43 helpers) | Structurally unreachable under injection pattern | Yes — accept-as-dead or rewrite, separate ADR | **Hard skip** — accept as dead |
+
+## Phase 10A — iOS notification paths via macOS runner (ADR-005 § A)
+
+**Goal:** close the iOS-specific arms of
+`lib/pages/notifications/notification_service.dart` that the
+ADR-002 macOS-cost framing deferred.
+
+**Workflow change:** add a fourth CI job `integration-test-ios` parallel to
+`integration-test`:
+
+- `runs-on: macos-14` (free for public/open-source repos under GitHub's
+  current billing; verify on first run that the org is opted in).
+- Boot an iOS Simulator via `xcrun simctl` rather than a third-party action —
+  the macos-14 runner ships with Xcode 15+ and the iOS sim is pre-installed.
+- Run `flutter test integration_test --coverage --coverage-path
+  coverage/integration_ios.info -d "iPhone 15"` (or whatever sim name the
+  `xcrun simctl list devices` step surfaces).
+- Reuse the existing
+  `--dart-define=SENTRY_DSN=https://test@dsn.example.local/0` from the
+  Android job for symmetry.
+
+**Test files:**
+
+- `integration_test/notifications_schedule_ios_test.dart` — mirror of
+  `notifications_schedule_test.dart` but exercises the **iOS-specific
+  branches** that the Android job cannot reach:
+  - `IOSFlutterLocalNotificationsPlugin.requestPermissions` happy path +
+    denied path (the Android job uses the Android plugin variant).
+  - `DarwinInitializationSettings` permission flags (`requestAlertPermission`,
+    `requestBadgePermission`, `requestSoundPermission`).
+  - The `Platform.isIOS` arm of `supportsReminderSettings()` (the Android job
+    only hits the `Platform.isAndroid` arm).
+
+**Gate:** new `scripts/check_ios_integration_coverage.dart` sibling of
+`scripts/check_integration_coverage.dart`. Single per-file floor:
+`lib/pages/notifications/notification_service.dart` ≥ 75% under the iOS
+invocation alone (will exceed 95% post-merge with Android intg lcov).
+
+**Aggregate-gate merge:** extend the coverage-aggregate job to download a
+third artifact (`coverage-integration-ios-lcov`) and pass it as a third input
+to `scripts/merge_lcov.dart`. The merge script already accepts N inputs.
+
+**Expected lift:** `notification_service.dart` aggregate % 90.6% → ~98%;
+~15 new raw lines into the aggregate denominator.
+
+**Risk:** macOS-runner cold start ~3-4 min + iOS sim boot ~60-90s. Total job
+time ≈ 6-8 min; acceptable. If it ever flakes, set `continue-on-error: true`
+on the gate step and require the aggregate gate to pass — symmetric with the
+existing Android emulator job's flake tolerance.
+
+## Phase 10B — `bootstrapApp()` extraction for main.dart (ADR-005 § B)
+
+**Goal:** close the foreground bootstrap of `lib/main.dart` — currently 1.7%
+unit + 59.3% via integration `MyApp` widget = ~60% post-merge. Lines 104-156
+(`main()` body + `initializeApp`) are unreachable because `Firebase.initializeApp`
+in the test would need either secret-injected `firebase_options.dart` or a
+fake Firebase app, and `main()` calls these directly.
+
+**Production-code change — 4th sanctioned exception under the coverage
+initiative:**
+
+- Extract `Future<Widget> bootstrapApp({FirebaseApp? firebaseApp,
+  WorkmanagerPlatform? workmanager, SentryService? sentryService, ...})`
+  from the current `main()` body. The helper does **everything `main()` does
+  except `runApp`** — that one line stays in `main()` so `bootstrapApp()` is
+  callable from an integration test that uses its own pump.
+- `main()` becomes a 2-line shim:
+  ```dart
+  Future<void> main() async {
+    final app = await bootstrapApp();
+    runApp(app);
+  }
+  ```
+- Pattern is identical in shape to ADR-001's `firestore` named-param
+  injection (R1) and ADR-004's extension of it (R9). Behaviour-preserving for
+  production: every default value equals the current direct call.
+
+**Test files:**
+
+- `integration_test/bootstrap_full_test.dart` — calls
+  `await bootstrapApp(firebaseApp: FakeFirebaseApp(), ...)` directly, asserts
+  the returned widget tree is a `MultiProvider(... MyApp ...)`, then pumps
+  through the integration_test binding to drive the same lifecycle paths the
+  existing `bootstrap_smoke_test.dart` already covers — but **this time
+  exercising the lines that build that widget tree, not just the tree
+  itself**.
+
+**Gate:** raise the per-file floor for `lib/main.dart` from "covered by
+MyApp alone" to a new explicit floor of 65% in
+`scripts/check_integration_coverage.dart`.
+
+**Expected lift:** `main.dart` aggregate % ~60% → ~85%; +50 lines into the
+aggregate denominator. `callbackDispatcher` (lines 42-89) stays uncovered —
+that's a background Workmanager entry-point still blocked by the lack of a
+background-task harness; explicitly out of Phase 10B scope.
+
+**Risk:** the refactor must preserve the existing `main()` semantics line-
+for-line for both Android release builds and web release builds. CI's
+`build-android` + `build-web` jobs are the safety net — both build the
+app from `main()` and surface any regression. Add a smoke `flutter analyze`
+diff check to PR review.
+
+## Phase 10C — Web platform test gate (ADR-005 § C)
+
+**Goal:** close the gate hole — `build-web` and `build-dev-web` currently
+build and deploy without any test step.
+
+**Workflow change:** new CI job `unit-test-web`:
+
+- `runs-on: ubuntu-latest` (Chrome headless is available on Linux runners; no
+  macOS needed for this one).
+- Steps: checkout → flutter setup (already cached from build-android) →
+  `flutter pub get` → `flutter test --platform chrome --coverage`.
+- `--platform chrome` runs the same `test/` suite under Chrome's `dart2js`
+  compiler — surfaces any test that accidentally depends on `dart:io` or
+  Android-specific plugin channel mocks.
+- Upload `coverage/lcov.info` as `coverage-web-lcov` artifact (filename
+  uniqueness avoids clobbering the unit job's `coverage-lcov`).
+
+**Gate:** **don't gate strictly on the first run.** Web-platform test
+execution will likely fail in some files that mock Android-specific plugin
+channels (path_provider, workmanager). Land the job with
+`continue-on-error: true` on the test step, surface the lcov as an artifact,
+review the first run's failure modes in PR review, and ratchet the gate
+once the suite is green under `--platform chrome`.
+
+**Expected lift:** unknown — likely 0-10 new lines (web-specific `kIsWeb`
+branches), but the **gate hole itself is the real motivation**.
+
+**Aggregate-gate merge:** once green, add the web lcov as a fourth input to
+`scripts/merge_lcov.dart` in the coverage-aggregate job.
+
+## Phase 10D — logger_service.dart residual lines (optional, recommended **decline**)
+
+5 lines total split across two structurally separate causes:
+
+- Lines 17-18: empty-DSN if-branch, dead under CI's `--dart-define=SENTRY_DSN=...`.
+  Fix would be dual-invocation pattern-2 of ADR-001 (one CI run with the
+  define, one without) + lcov merge. ~3 min extra CI time for ~0.03 pt
+  aggregate gain.
+- Lines 29-31: outer catch branch, swallowed by `sentry_flutter` SDK internals.
+  Fix would require either (a) a runtime-readable `_sentryDsn` (production
+  change — would need a 5th ADR-005 sub-decision), or (b) a different
+  exception-injection strategy.
+
+**Recommendation: decline both in Phase 10.** Net aggregate impact ~0.07 pt;
+both are documented as accepted risk in the Round 9 still-deferred table.
+Revisit only if Phase 10A+B+C lift consumes the 3 pt headroom.
+
+## Hard skips for Phase 10
+
+These items are listed for completeness — they are **explicitly out of scope**
+and should not be attempted in Phase 10:
+
+- **`callbackDispatcher` (Workmanager background entry-point, lines 42-89 of
+  `main.dart`).** Foreground integration tests cannot trigger a background
+  `Workmanager().executeTask` callback. Needs Patrol's background task driver
+  or a custom emulator harness — a separate ADR with motivation beyond
+  coverage (e.g. "we need to confirm the periodic worker actually fires after
+  reboot").
+- **`firebase_functions.dart` `?? FirebaseFirestore.instance` fallback right-
+  hand-sides (43 lines).** Structurally unreachable under the injection
+  pattern. Accept as dead lines under the existing tier-1 50% floor (file is
+  93.8%), or rewrite the helpers to not use the fallback shape — separate
+  refactor ADR.
+
+## Aggregate-floor target after Phase 10
+
+| Step | Aggregate % | Floor proposal | Headroom |
+|---|---|---|---|
+| Round 9 (current) | 91.83% | 89% | 2.83 pt |
+| + Phase 10A (iOS notifications, ~15 lines) | ~92.0% | 89% | 3.0 pt |
+| + Phase 10B (bootstrapApp, ~50 lines) | ~92.8% | 90% | 2.8 pt |
+| + Phase 10C (web, est 0-10 lines) | ~92.9% | 90% | 2.9 pt |
+
+Floor ratchet recommendation: aggregate **89% → 90%**, applied once all
+three sub-phases land and the first three CI runs confirm the aggregate %.
+
+Per-tier and per-file floors in `scripts/check_coverage.dart` and
+`scripts/check_integration_coverage.dart` are unchanged.
+
+## Execution sequence
+
+Three small PRs against `tests/phase101-2026`, matching the cadence of
+phases 6→9 (one PR per ADR sub-decision):
+
+1. **PR 10A — iOS notification paths**
+   - `docs/adr/ADR-005-phase-10-macos-runner-ios-and-web-coverage.md` (§ A only initially)
+   - `integration_test/notifications_schedule_ios_test.dart`
+   - `scripts/check_ios_integration_coverage.dart`
+   - `.github/workflows/main.yml` — new `integration-test-ios` job + aggregate merge update
+
+2. **PR 10B — bootstrapApp extraction**
+   - ADR-005 § B addendum
+   - `lib/main.dart` — `bootstrapApp()` extraction (4th sanctioned exception)
+   - `integration_test/bootstrap_full_test.dart`
+   - `scripts/check_integration_coverage.dart` — `main.dart` per-file floor 65%
+
+3. **PR 10C — web test gate**
+   - ADR-005 § C addendum
+   - `.github/workflows/main.yml` — new `unit-test-web` job (`continue-on-error: true` initially)
+   - Triage report on first run's failures filed as follow-up issues
+
+4. **Doc bundle commit** (in PR 10A or a precursor):
+   - The currently-uncommitted `docs/coverage-status.md` edit (post-correction
+     numbers polish in § Aggregate-floor derivation) goes with PR 10A.
+   - Add a Round 10 section to `coverage-status.md` after each PR lands.
+
+## Open questions before starting
+
+1. Is the GitHub org opted into the open-source macOS-runner billing program?
+   First Phase 10A run will surface a billing error if not — confirm before
+   merging the new job.
+2. Does `flutter test --platform chrome` work with the current Flutter 3.41.6
+   pin given the project's dependency graph? Sanity-check by running locally
+   once before opening PR 10C.
+3. Is the `bootstrapApp()` extraction acceptable to reviewers as a fourth
+   sanctioned production-code exception? ADR-005 § B must make the case
+   explicitly — parallel to ADR-001's `firestore` precedent and ADR-002 PR
+   #266's `resetForTest()`.
+
+## Tooling reuse
+
+- `scripts/_lcov_parser.dart` — already supports N-input merging via
+  `parseLcovInputs`; no changes needed for Phase 10A or 10C.
+- `scripts/merge_lcov.dart` — already accepts N positional args; coverage-
+  aggregate job will pass 3 (or 4) artifacts instead of 2.
+- `test/helpers/widget_test_scaffold.dart` — applies to integration tests
+  unchanged. iOS-specific tests in 10A may need a `darwin_test_scaffold.dart`
+  sibling if iOS-specific GetIt fakes diverge from the cross-platform ones;
+  evaluate during PR 10A authoring.
+- `qe-test-architect` (Agentic QE Fleet) — proven in Round 9 for pure-Dart
+  unit tests against `FakeFirebaseFirestore`. Less obviously a fit for the
+  integration-test files in 10A/10B (platform-channel mocking + binding
+  setup is finicky) — author those by hand, reserve the agent for any
+  pure-Dart helpers that come out of the bootstrap extraction.

--- a/docs/coverage-status.md
+++ b/docs/coverage-status.md
@@ -1205,11 +1205,16 @@ Phase 9 only adds unit-pipeline tests; the integration pipeline is
 unchanged. The aggregate estimate:
 
 ```
-Unit hits (R9):            5800 / 6493 = 89.33%
-Integration delta (R8):    +163 lines  (unchanged — same 4 files)
-Aggregate (R9 est):        5963 / 6493 = 91.84%
-Aggregate floor proposal:  91.84% − 3 pt headroom = 88.84% → 89%
+Unit hits (R9, post-correction):  5754 / 6444 = 89.29%
+Integration delta (R8):           +163 lines  (unchanged — same 4 files)
+Aggregate (R9 est):               5917 / 6444 = 91.83%
+Aggregate floor proposal:         91.83% − 3 pt headroom = 88.83% → 89%
 ```
+
+(The original Phase 9 proposal targeted 5800/6493 = 89.33% with aggregate
+5963/6493 = 91.84%; the post-review dead-code removal — see § "Post-review
+correction" above — dropped 9 raw lines from both numerator and denominator,
+landing at 5754/6444. The 89% aggregate floor proposal holds either way.)
 
 The 3 pt headroom matches every prior ADR-001/002/003 ratchet step.
 First CI run on `tests/phase9-2026` will reveal the actual aggregate %

--- a/docs/coverage-status.md
+++ b/docs/coverage-status.md
@@ -1259,6 +1259,245 @@ rather than by hand. The agent's output was reviewed against the ADR-004
 hard constraints (no `lib/` modifications, no platform-channel mocks,
 no skipped tests, analyzer clean) — all four held without iteration.
 
+## Round 10 — Phase 10 ADR-005 execution (macOS-runner iOS coverage, bootstrapApp extraction, web test gate)
+
+Generated: 2026-05-25 — executes the three sub-decisions adopted in
+[`docs/adr/ADR-005-phase-10-macos-runner-ios-and-web-coverage.md`](adr/ADR-005-phase-10-macos-runner-ios-and-web-coverage.md).
+This round is anchored on the constraint shift that open-source macOS
+runners are free on GitHub Actions, which unblocks the iOS coverage items
+ADR-002 / Round 9 deferred under a 10× cost framing. Round 10 also closes
+one gap prior phases missed (the `main.dart` foreground bootstrap, stuck
+at ~60% post-Round-7) and lands a **telemetry-only** web-platform job —
+`unit-test-web-telemetry` — that surfaces failure modes of running the
+unit suite under Chrome but does NOT yet gate anything. A strict web
+gate (rename to `unit-test-web`, drop `continue-on-error: true`, wire
+into `coverage-aggregate` needs, add a `scripts/check_web_coverage.dart`
+sibling, merge web lcov into the aggregate) remains deferred until the
+first telemetry runs surface their failure modes — tracked in the
+"Still deferred (post Phase 10)" table below.
+
+### Headline (estimated — first CI run will confirm)
+
+| Metric | Round 9 | Round 10 (est) | Change |
+|---|---|---|---|
+| Unit tests | 634 + 8 skipped | unchanged | 0 |
+| Integration tests (Android emulator) | 5 | unchanged | 0 |
+| Integration tests (iOS simulator) | 0 | **9** (1 new file, 5 groups) | +9 |
+| Integration tests (bootstrap, full) | 0 (smoke only) | **5** (1 new file, 4 groups) | +5 |
+| `lib/main.dart` aggregate % | ~59.3% | ~75-85% (est) | +15-25 pts |
+| `lib/pages/notifications/notification_service.dart` aggregate % | ~90.6% | ~97% (est) | +6 pts |
+| CI jobs | 3 | **5** (+integration-test-ios as gate, +unit-test-web-telemetry as non-gating telemetry) | +2 |
+| Unit-pipeline global floor | 85% | unchanged | 0 |
+| Integration-pipeline `lib/main.dart` per-file floor | 50% | **65%** | +15 pts |
+| Aggregate global floor | 89% | **90%** (post-merge) | +1 pt |
+
+### What landed
+
+#### PR 10A — iOS notification paths via macOS-14 runner (ADR-005 § A)
+
+- **`integration_test/notifications_schedule_ios_test.dart`** (~250 LOC,
+  9 testWidgets in 5 groups). Mirrors the Android sibling but exercises
+  iOS-specific arms on a real iOS Simulator under
+  `IntegrationTestWidgetsFlutterBinding`:
+  - `supportsReminderSettings()` returns false on real iOS binding (no
+    `debugDefaultTargetPlatformOverride` needed — the macos-14 + iOS sim
+    sets `defaultTargetPlatform = iOS` naturally).
+  - `init()` happy path reaches `plugin.initialize` via the iOS plugin
+    variant (`DarwinInitializationSettings`).
+  - `init()` is idempotent on iOS (second call short-circuits via
+    `_isInitialized`).
+  - `init()` catch branch on iOS forwards `IOS_TZ_FAIL` PlatformException
+    to `IncidentLogger` and still calls `plugin.initialize` on the
+    Asia/Jerusalem fallback.
+  - `initializeNotification()` early-returns on iOS without reaching
+    permission / schedule / toast calls.
+  - `scheduleNotification()` direct call reaches `plugin.zonedSchedule`
+    on iOS (bypasses the `supportsReminderSettings` gate to exercise
+    cross-platform scheduling on the real iOS plugin).
+  - `cancelNotifications(id)` and `cancelNotifications(null)` reach
+    `plugin.cancel` / `plugin.cancelAll` on iOS.
+  - Explicitly skips `cancelNotifications(null, cancelWorker: true)` —
+    Workmanager has no iOS implementation; documented in the file
+    header.
+- **`scripts/check_ios_integration_coverage.dart`** (new gate). Sibling
+  of `check_integration_coverage.dart`. Reads `coverage/integration_ios.info`
+  produced by the new `integration-test-ios` CI job, enforces a 60%
+  per-file floor on `lib/pages/notifications/notification_service.dart`
+  under the iOS invocation alone. Floor sized below the expected ~70-80%
+  to absorb iOS surface differences vs Android (no Workmanager arm).
+- **`.github/workflows/main.yml`** — new `integration-test-ios` job on
+  `macos-14`. Boots the first available iPhone simulator via
+  `xcrun simctl` (no third-party action — macos-14 ships with Xcode +
+  iOS sim pre-installed), runs only the iOS test file with
+  `-d "$DEVICE_ID"`. Uploads `coverage-integration-ios-lcov` artifact.
+- **`coverage-aggregate` job updated** — `needs:` extended to
+  `[build-android, integration-test, integration-test-ios]`; the
+  upstream-result check covers all three; downloads the iOS lcov as a
+  third artifact and passes it as a third input to
+  `scripts/merge_lcov.dart` (which already accepts N positional args from
+  PR #266's refactor).
+
+#### PR 10B — `bootstrapApp()` extraction (ADR-005 § B, 4th sanctioned production exception)
+
+- **`lib/main.dart`** — extracted
+  `Future<Widget> bootstrapApp({firebaseInitializer, locatorSetup,
+  workmanagerInitializer})` from the previous `main()` body. The helper
+  performs `WidgetsFlutterBinding.ensureInitialized()` + Firebase init +
+  service-locator setup + (on non-web) Workmanager init, then returns
+  the `MultiProvider(... MyApp ...)` widget tree. Production `main()`
+  reduced to:
+  ```dart
+  void main() async {
+    final app = await bootstrapApp();
+    final IncidentLoggerService sentryService =
+        GetIt.instance<IncidentLoggerService>();
+    await sentryService.initializeSentry(app);
+  }
+  ```
+  `initializeApp(...)` also gained matching `firebaseInitializer` +
+  `locatorSetup` injection seams (its only caller, `bootstrapApp`,
+  forwards them through). All three named parameters default to the
+  exact pre-extraction calls — behavior-preserving for production by
+  construction. The CI `build-android` + `build-web` jobs build the app
+  starting from `main()` and surface any regression.
+  - **Fourth sanctioned production-code exception** to the no-production-
+    changes guard rail, alongside:
+    1. ADR-001 Round 1 — `firestore` named-param injection on 14 helpers
+       in `firebase_functions.dart`.
+    2. ADR-002 PR #266 — `@visibleForTesting
+       NotificationsService.resetForTest()`.
+    3. ADR-004 Round 9 — `firestore` injection extended to 29 more
+       helpers in `firebase_functions.dart`.
+- **`integration_test/bootstrap_full_test.dart`** (~250 LOC, 5
+  testWidgets in 4 groups). Calls `bootstrapApp(...)` directly with
+  fakes:
+  - Group 1 — return shape: asserts all three injection seams fire
+    (firebase, locator, workmanager), that the returned `MultiProvider`
+    pumps to a tree containing exactly one `MyApp`.
+  - Group 2 — pumps the returned widget: first frame renders the
+    `CircularProgressIndicator` placeholder (locale='') branch;
+    second-pass after async pumps settles to one of `FirstPage` /
+    `Introduction` / progress (identical settle shape to the Phase-7
+    `bootstrap_smoke_test.dart`).
+  - Group 3 — default-fallback branch: omits `workmanagerInitializer`
+    and asserts the fallback closure calls `Workmanager().initialize`
+    via the `_SilentWorkmanager.register()` recorder.
+  - Group 4 — `initializeApp(...)` standalone: asserts both injection
+    seams fire and that fake services are registered post-call.
+- **`scripts/check_integration_coverage.dart`** — `lib/main.dart`
+  per-file floor raised 50.0 → 65.0 with a comment explaining the
+  ratchet rationale (bootstrap-path now reachable; `callbackDispatcher`
+  lines 42-89 stay uncovered).
+
+#### PR 10C — web test telemetry job (ADR-005 § C — landed as TELEMETRY, not yet a gate)
+
+- **`.github/workflows/main.yml`** — new `unit-test-web-telemetry` job
+  on `ubuntu-latest` (renamed from the originally-planned
+  `unit-test-web` to make its non-gating role obvious in CI logs and PR
+  review). Runs `flutter test --platform chrome --coverage` with the
+  same synthetic `SENTRY_DSN` dart-define the other jobs use.
+  Uploads `coverage-web-lcov` artifact (`if-no-files-found: warn` so
+  the upload succeeds when `flutter test` crashes before emitting lcov).
+- **Deliberately green-on-failure during the triage phase:**
+  - `continue-on-error: true` on the test step makes a `flutter test`
+    crash report job-success — failures DO NOT fail this job.
+  - The job is NOT in `coverage-aggregate`'s `needs:` list, so a
+    missing/empty `coverage/lcov.info` cannot block the aggregate.
+  - Step name explicitly says "telemetry — failures do NOT fail this
+    job" so reviewers reading CI logs cannot mistake a green tick for
+    a working gate.
+- **Flip-to-gate criteria** (tracked as "still deferred (post Phase 10)"
+  below): once the suite is green under `--platform chrome`, rename
+  the job to `unit-test-web`, remove `continue-on-error: true`,
+  introduce `scripts/check_web_coverage.dart` (sibling pattern), wire
+  the job into `coverage-aggregate`'s `needs:` list, and add the web
+  lcov as a fourth input to `scripts/merge_lcov.dart`. None of this
+  happens until the first telemetry runs surface their failure modes.
+
+This deliberate split — landing telemetry NOT a gate — surfaced during
+PR 10B review (P2 finding): the original framing as "closes the web
+gate" was misleading because `continue-on-error: true` + not-in-needs
+meant Chrome test failures still produced a green workflow job. The
+rename + explicit step-name warning + `if-no-files-found: warn` on the
+upload make the non-gating role unambiguous; the flip to a real gate
+is a future ADR-005 § C follow-up, not part of this round.
+
+### Per-file deltas (estimated; first CI run will confirm)
+
+| File | R9 | R10 (est) |
+|---|---|---|
+| `lib/main.dart` (aggregate) | ~59.3% | ~75-85% |
+| `lib/pages/notifications/notification_service.dart` (aggregate) | ~90.6% | ~97% |
+| Aggregate global coverage | ~91.83% | ~92.8% |
+
+### Production code changes — summary
+
+| Change | LOC | Justification |
+|---|---|---|
+| `bootstrapApp()` extraction + `initializeApp(...)` injection seams in `lib/main.dart` | ~30 LOC added, ~45 LOC reshuffled | ADR-005 § B; 4th sanctioned exception; defaults exactly match pre-extraction behavior; CI `build-android` + `build-web` surface any production regression |
+| **No other `lib/` files modified** | 0 | `git diff lib/` outside `main.dart` is empty for Round 10 |
+
+### `skip: true` tests
+
+No new skips. The 8 pre-existing skips from Round 1 (3 in
+`Journal_test.dart`, 5 in `menu_test.dart`) remain untouched.
+
+### Still deferred (post Phase 10)
+
+The list shrinks by two items (iOS-notification paths closed via the
+new `integration-test-ios` gate; `main.dart` foreground bootstrap
+closed via the `bootstrapApp()` extraction + `bootstrap_full_test.dart`).
+The web-platform gate hole is **partially addressed** — telemetry
+lands (`unit-test-web-telemetry`), but the strict gate stays deferred
+(see entry below). Remaining accepted-risk items:
+
+| Item | Why still deferred | Unblock criterion |
+|---|---|---|
+| `callbackDispatcher` (Workmanager background entry-point, `main.dart` lines 42-89) | Foreground integration tests cannot trigger a background `Workmanager().executeTask` callback | Background-worker test harness (e.g. Patrol's background task driver) — explicitly out of ADR-005 scope; needs its own ADR with motivation beyond coverage |
+| `logger_service.dart` lines 17-18 (empty-DSN if-branch) | Structurally dead in CI under `--dart-define=SENTRY_DSN=...` | Dual-invocation pattern-2 of ADR-001; benefit is ~0.03 pt aggregate — revisit only if the 90% floor strains the 3 pt headroom |
+| `logger_service.dart` lines 29-31 (outer catch) | Sentry SDK swallows the channel `PlatformException` internally | Runtime-readable `_sentryDsn` (5th production exception) — would require a new ADR |
+| `firebase_functions.dart` residual ~43 `?? FirebaseFirestore.instance` fallback lines | Structurally unreachable under the injection pattern | Accept as dead under the existing tier-1 50% floor (file at 93.8%) or rewrite helpers to not use the fallback shape — separate refactor ADR |
+| Web-platform `unit-test-web-telemetry` → `unit-test-web` strict gate flip | Initial landing is `continue-on-error: true` + not in `coverage-aggregate` needs (deliberately green-on-failure during triage) | Triage follow-up issues from first telemetry runs; rename job, drop `continue-on-error`, add `scripts/check_web_coverage.dart`, wire into aggregate `needs:` + `merge_lcov.dart` |
+| iOS-specific arms that need `cancelWorker: true` | Workmanager has no iOS implementation | Future ADR if iOS background-fetch substitute is ever wired |
+
+### CI floor ratchets (proposed — confirm after first CI run)
+
+- `scripts/check_integration_coverage.dart` `lib/main.dart` per-file:
+  **50.0 → 65.0** (landed in PR 10B).
+- `scripts/check_aggregate_coverage.dart` aggregate global floor: **89%
+  → 90%** (proposed; land in a follow-up after first three CI runs
+  confirm the aggregate %).
+
+### Doc bundling note
+
+This round also commits the post-correction numbers polish in the
+Round 9 § "Aggregate floor — estimated post-merge" section
+(`5800/6493 → 5754/6444` etc.) that had been sitting uncommitted on the
+working tree since the Round 9 PR-268 review.
+
+### Tooling used
+
+- All test files authored by hand. The `qe-test-architect` agent (used
+  in Round 9) was not engaged: the Round 10 work is integration-test +
+  CI-workflow + platform-channel-mocking heavy, where the agent's
+  pure-Dart-against-fakes specialty doesn't apply.
+
+### Open questions (still unresolved at landing)
+
+Carried over from the Phase 10 plan; each will be answered by the first
+CI run on this branch:
+
+1. **Is the GitHub org opted into the open-source macOS-runner billing
+   program?** First `integration-test-ios` job run will surface a billing
+   error if not. If blocked, the job can be marked `continue-on-error: true`
+   while the org opts in.
+2. **Does `flutter test --platform chrome` work with the current Flutter
+   3.41.6 pin given the project's dependency graph?** Triaged after the
+   first `unit-test-web` job run; that's exactly what `continue-on-error:
+   true` is there for.
+3. **`bootstrapApp()` extraction reviewer signoff** — landed; ADR-005 § B
+   makes the case explicitly. PR review will confirm or push back.
+
 
 
 1. **Real production widgets only.** Never duplicate a `lib/...dart` widget into `test/...dart` and test the duplicate. The pattern in `test/helpers/widget_test_scaffold.dart` is the only sanctioned shape: register fakes on GetIt, wrap in MultiProvider + MaterialApp + ScreenUtilInit.

--- a/integration_test/bootstrap_full_test.dart
+++ b/integration_test/bootstrap_full_test.dart
@@ -1,0 +1,323 @@
+// Phase 10B (ADR-005 § B): integration test that exercises the full
+// foreground bootstrap of `lib/main.dart` by calling the extracted
+// `bootstrapApp(...)` directly.
+//
+// The Phase-7 sibling (`bootstrap_smoke_test.dart`) hand-built the same
+// MultiProvider tree that `main()` builds and pumped MyApp from it — this
+// covered the bulk of MyApp's lifecycle (initState / build / changeLocale /
+// didChangeAppLifecycleState) but left lines 104-156 of main.dart
+// (`initializeApp` body + `main` body + the MultiProvider construction)
+// outside the test's reach. ADR-005 § B sanctioned the
+// `bootstrapApp(...)` extraction specifically to make those lines
+// testable; this file exercises them.
+//
+// Injection seams used (none of these change production behavior because
+// they all default to the previous in-`main()` calls):
+//   * `firebaseInitializer: () async {}` — skips the real
+//     `Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform)`
+//     call which would require either the secret-injected
+//     `firebase_options.dart` to be valid for this test or a network round-
+//     trip the integration_test binding does not provide. The downstream
+//     `loadAppInformation` / `loadUserInformation` calls in MyApp.build
+//     still hit `FirebaseFirestore.instance` and fail, which routes through
+//     MyApp's `.catchError` into the Introduction fallback — identical
+//     behavior to `bootstrap_smoke_test.dart`.
+//   * `locatorSetup` — pass `registerTestServices` directly so the same
+//     in-memory fakes the rest of the unit/integration suites use are
+//     registered, and the production `setupLocator` (which would
+//     `registerLazySingleton` concrete impls and throw on duplicate
+//     registration after our fakes are in place) is bypassed.
+//   * `workmanagerInitializer: () {}` — no-op; the underlying
+//     `WorkmanagerPlatform.instance` is replaced with the
+//     `_SilentWorkmanager` recorder so any downstream `Workmanager()` calls
+//     in MyApp's lifecycle complete cleanly.
+//
+// Production `main()` calls `bootstrapApp()` with no args. Its defaults
+// match the previous in-`main()` body line-for-line. The CI `build-android`
+// + `build-web` jobs build the app starting from `main()` and surface any
+// regression.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mazilon/AnalyticsService.dart';
+import 'package:mazilon/Locale/locale_service.dart';
+import 'package:mazilon/main.dart'
+    show MyApp, bootstrapApp, initializeApp;
+import 'package:mazilon/pages/SignIn_Pages/firstPage.dart';
+import 'package:mazilon/pages/SignIn_Pages/introduction.dart';
+import 'package:provider/provider.dart';
+// ignore: depend_on_referenced_packages
+import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
+
+import '../test/helpers/widget_test_scaffold.dart';
+
+class _SilentWorkmanager extends WorkmanagerPlatform {
+  _SilentWorkmanager._() : super();
+  static final _SilentWorkmanager _shared = _SilentWorkmanager._();
+  final List<String> calls = [];
+
+  static _SilentWorkmanager register() {
+    WorkmanagerPlatform.instance = _shared;
+    _shared.calls.clear();
+    return _shared;
+  }
+
+  @override
+  Future<void> initialize(Function callbackDispatcher,
+      {bool isInDebugMode = false}) async {
+    calls.add('initialize');
+  }
+
+  @override
+  Future<void> cancelAll() async {
+    calls.add('cancelAll');
+  }
+
+  @override
+  Future<void> registerOneOffTask(String uniqueName, String taskName,
+      {Map<String, dynamic>? inputData,
+      Duration? initialDelay,
+      Constraints? constraints,
+      ExistingWorkPolicy? existingWorkPolicy,
+      BackoffPolicy? backoffPolicy,
+      Duration? backoffPolicyDelay,
+      String? tag,
+      OutOfQuotaPolicy? outOfQuotaPolicy}) async {}
+
+  @override
+  Future<void> registerPeriodicTask(String uniqueName, String taskName,
+      {Duration? frequency,
+      Duration? flexInterval,
+      Map<String, dynamic>? inputData,
+      Duration? initialDelay,
+      Constraints? constraints,
+      ExistingPeriodicWorkPolicy? existingWorkPolicy,
+      BackoffPolicy? backoffPolicy,
+      Duration? backoffPolicyDelay,
+      String? tag}) async {}
+
+  @override
+  Future<void> cancelByUniqueName(String uniqueName) async {}
+
+  @override
+  Future<void> cancelByTag(String tag) async {}
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel =
+      MethodChannel('plugins.flutter.io/path_provider');
+  const sharedPrefsChannel =
+      MethodChannel('plugins.flutter.io/shared_preferences');
+
+  late _SilentWorkmanager fakeWm;
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    fakeWm = _SilentWorkmanager.register();
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      ..setMockMethodCallHandler(pathProviderChannel, (call) async {
+        switch (call.method) {
+          case 'getApplicationDocumentsDirectory':
+          case 'getApplicationSupportDirectory':
+          case 'getTemporaryDirectory':
+            return '/tmp/aqe-bootstrap-full';
+          default:
+            return null;
+        }
+      })
+      // PhonePageData.loadItemsFromPrefs reads via shared_preferences; return
+      // an empty store so the cascade completes without touching real prefs.
+      ..setMockMethodCallHandler(sharedPrefsChannel, (call) async {
+        if (call.method == 'getAll') return <String, Object>{};
+        return null;
+      });
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      ..setMockMethodCallHandler(pathProviderChannel, null)
+      ..setMockMethodCallHandler(sharedPrefsChannel, null);
+    await GetIt.instance.reset();
+  });
+
+  group('bootstrapApp() return shape', () {
+    testWidgets(
+        'returns the same MultiProvider tree shape that pre-extraction main() built',
+        (tester) async {
+      var firebaseCalled = false;
+      var locatorCalled = false;
+      var workmanagerCalled = false;
+
+      final widget = await bootstrapApp(
+        firebaseInitializer: () async {
+          firebaseCalled = true;
+        },
+        locatorSetup: () {
+          locatorCalled = true;
+          registerTestServices(locale: 'en');
+        },
+        workmanagerInitializer: () {
+          workmanagerCalled = true;
+        },
+      );
+
+      expect(firebaseCalled, isTrue,
+          reason: 'bootstrapApp must call firebaseInitializer');
+      expect(locatorCalled, isTrue,
+          reason: 'bootstrapApp must call locatorSetup');
+      // workmanagerInitializer only runs on non-web; integration_test binding
+      // on Android emulator => kIsWeb is false, so it must have run.
+      expect(workmanagerCalled, isTrue,
+          reason:
+              'bootstrapApp must call workmanagerInitializer on non-web platforms');
+
+      // Top-level shape: MultiProvider wrapping MyApp. The provider package
+      // does not expose providers/child as public getters, so we verify the
+      // shape by pumping the widget and asserting the resulting tree
+      // contains the MultiProvider + MyApp pair the pre-extraction main()
+      // produced.
+      expect(widget, isA<MultiProvider>(),
+          reason:
+              'bootstrapApp must return a MultiProvider as its root widget');
+
+      await tester.pumpWidget(widget);
+      await tester.pump();
+
+      expect(find.byType(MultiProvider), findsOneWidget,
+          reason: 'pumped tree must contain the bootstrap MultiProvider');
+      expect(find.byType(MyApp), findsOneWidget,
+          reason: 'pumped tree must contain MyApp under the MultiProvider');
+    });
+  });
+
+  group('bootstrapApp() pumps a working MyApp tree', () {
+    testWidgets(
+        'first frame after bootstrapApp shows the CircularProgressIndicator placeholder',
+        (tester) async {
+      final widget = await bootstrapApp(
+        firebaseInitializer: () async {},
+        locatorSetup: () => registerTestServices(locale: 'en'),
+        workmanagerInitializer: () {},
+      );
+
+      await tester.pumpWidget(widget);
+      // First frame: localeName is still '' so MyApp renders the bootstrap
+      // MaterialApp + CircularProgressIndicator placeholder (lines 399-406
+      // of main.dart, the pre-`ScreenUtilInit` branch).
+      await tester.pump();
+
+      expect(find.byType(MaterialApp), findsWidgets);
+      expect(find.byType(CircularProgressIndicator), findsWidgets);
+    });
+
+    testWidgets(
+        'MyApp settles to FirstPage or Introduction after async bootstrap (spinner is gone)',
+        (tester) async {
+      final widget = await bootstrapApp(
+        firebaseInitializer: () async {},
+        locatorSetup: () => registerTestServices(locale: 'en'),
+        workmanagerInitializer: () {},
+      );
+
+      await tester.pumpWidget(widget);
+
+      // Drive the async build cycle. MyApp.build kicks off a Future.wait of
+      // loadAppInformation / loadUserInformation / setLocale. The first two
+      // hit FirebaseFirestore.instance (no Firebase initialised) and fail,
+      // routing through MyApp's .catchError → Introduction. setLocale
+      // completes via the in-memory PersistentMemoryService fake.
+      //
+      // Pump generously (2s total) so a slow CI agent still settles; we then
+      // assert the STRONGER condition that the spinner is gone and the
+      // bootstrap reached a terminal widget. A bootstrap that hangs on the
+      // CircularProgressIndicator placeholder forever (e.g. setLocale future
+      // never completes, or the localeName='' branch never flips) is a real
+      // regression — it should fail this test, not slip through.
+      for (int i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      final hasFirstPage = find.byType(FirstPage).evaluate().isNotEmpty;
+      final hasIntroduction = find.byType(Introduction).evaluate().isNotEmpty;
+      // STRONGER than the Phase-7 smoke test: we no longer accept a
+      // CircularProgressIndicator as a "settled" state. A bootstrap that
+      // never leaves the placeholder (e.g. setLocale future never
+      // completes, or the localeName='' → ScreenUtilInit transition is
+      // broken) is the exact regression Phase 10B is meant to catch — the
+      // raised main.dart per-file floor (50% → 65%) is meaningless if the
+      // test passes on a bootstrap that hung.
+      expect(
+        hasFirstPage || hasIntroduction,
+        isTrue,
+        reason:
+            'After 2s of async pumps MyApp must have left the loading '
+            'placeholder and rendered FirstPage (success path) or '
+            'Introduction (catchError fallback path). If neither is found, '
+            'the bootstrap is stuck on the CircularProgressIndicator '
+            'placeholder from main.dart lines 399-406 — that is a real '
+            'regression in the localeName=""→ScreenUtilInit transition, '
+            'not a flake.',
+      );
+    });
+  });
+
+  group('bootstrapApp() default branches (workmanagerInitializer absent)', () {
+    testWidgets(
+        'when workmanagerInitializer is omitted, falls back to Workmanager().initialize',
+        (tester) async {
+      fakeWm.calls.clear();
+
+      final widget = await bootstrapApp(
+        firebaseInitializer: () async {},
+        locatorSetup: () => registerTestServices(locale: 'en'),
+        // workmanagerInitializer omitted → exercises the default-fallback
+        // closure that calls `Workmanager().initialize(callbackDispatcher,
+        // isInDebugMode: false)`. _SilentWorkmanager records the call.
+      );
+
+      // The default fallback fires Workmanager().initialize, which routes
+      // through WorkmanagerPlatform.instance (our _SilentWorkmanager).
+      expect(
+        fakeWm.calls,
+        contains('initialize'),
+        reason:
+            'default workmanagerInitializer must call Workmanager().initialize',
+      );
+
+      // Returned widget is still the expected MultiProvider shape — proves
+      // the workmanager branch did not derail the bootstrap.
+      expect(widget, isA<MultiProvider>());
+    });
+  });
+
+  group('initializeApp() default branches', () {
+    testWidgets(
+        'initializeApp() with firebaseInitializer override + locatorSetup override completes',
+        (tester) async {
+      var firebaseCalled = false;
+      var locatorCalled = false;
+
+      await initializeApp(
+        firebaseInitializer: () async {
+          firebaseCalled = true;
+        },
+        locatorSetup: () {
+          locatorCalled = true;
+          registerTestServices(locale: 'en');
+        },
+      );
+
+      expect(firebaseCalled, isTrue);
+      expect(locatorCalled, isTrue);
+      // After locator setup our fake should be registered.
+      expect(GetIt.instance.isRegistered<AnalyticsService>(), isTrue);
+      expect(GetIt.instance.isRegistered<LocaleService>(), isTrue);
+    });
+  });
+}

--- a/integration_test/bootstrap_full_test.dart
+++ b/integration_test/bootstrap_full_test.dart
@@ -44,13 +44,11 @@ import 'package:get_it/get_it.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mazilon/AnalyticsService.dart';
 import 'package:mazilon/Locale/locale_service.dart';
-import 'package:mazilon/main.dart'
-    show MyApp, bootstrapApp, initializeApp;
+import 'package:mazilon/main.dart' show MyApp, bootstrapApp, initializeApp;
 import 'package:mazilon/pages/SignIn_Pages/firstPage.dart';
 import 'package:mazilon/pages/SignIn_Pages/introduction.dart';
 import 'package:provider/provider.dart';
-// ignore: depend_on_referenced_packages
-import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
+import 'package:workmanager/workmanager.dart';
 
 import '../test/helpers/widget_test_scaffold.dart';
 
@@ -60,6 +58,11 @@ class _SilentWorkmanager extends WorkmanagerPlatform {
   final List<String> calls = [];
 
   static _SilentWorkmanager register() {
+    // Workmanager() lazily constructs a singleton whose constructor installs
+    // the real Android/iOS platform if the current platform is only a test
+    // fake. Prime that singleton first, then replace the platform with this
+    // recorder so the default fallback remains observable.
+    Workmanager();
     WorkmanagerPlatform.instance = _shared;
     _shared.calls.clear();
     return _shared;
@@ -109,8 +112,7 @@ class _SilentWorkmanager extends WorkmanagerPlatform {
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  const pathProviderChannel =
-      MethodChannel('plugins.flutter.io/path_provider');
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
   const sharedPrefsChannel =
       MethodChannel('plugins.flutter.io/shared_preferences');
 
@@ -255,8 +257,7 @@ void main() {
       expect(
         hasFirstPage || hasIntroduction,
         isTrue,
-        reason:
-            'After 2s of async pumps MyApp must have left the loading '
+        reason: 'After 2s of async pumps MyApp must have left the loading '
             'placeholder and rendered FirstPage (success path) or '
             'Introduction (catchError fallback path). If neither is found, '
             'the bootstrap is stuck on the CircularProgressIndicator '

--- a/integration_test/notifications_schedule_ios_test.dart
+++ b/integration_test/notifications_schedule_ios_test.dart
@@ -1,0 +1,325 @@
+// Phase 10A (ADR-005 § A): integration test for the iOS arms of
+// NotificationsService, running on a real iOS simulator under
+// integration_test/.
+//
+// The Android sibling (`notifications_schedule_test.dart`) exercises the
+// Android scheduling + init paths against the real Android binding. The
+// unit suite (`test/notifications/notification_service_initialize_test.dart`)
+// covers iOS behavior under `debugDefaultTargetPlatformOverride =
+// TargetPlatform.iOS`, but those tests run against the host VM binding —
+// iOS-specific channel-level surprises (Darwin plugin init, iOS
+// zonedSchedule payload shape, lack of Workmanager iOS impl) only surface
+// on a real iOS binding.
+//
+// This file runs on `macos-14` + iPhone simulator in the new
+// `integration-test-ios` CI job (see `.github/workflows/main.yml`). Per
+// ADR-002 hard rule #5 it is also verifiable locally by anyone with an
+// iOS simulator attached: `flutter test integration_test/
+// notifications_schedule_ios_test.dart -d "iPhone 15"`.
+//
+// Scope on iOS:
+//   * supportsReminderSettings() returns false on iOS — exercised against
+//     the real iOS defaultTargetPlatform (no override).
+//   * init() happy path — DarwinInitializationSettings reaches the iOS
+//     plugin's initialize via the dexterous.com/flutter/local_notifications
+//     MethodChannel.
+//   * init() catch branch — flutter_timezone throws, the fallback path
+//     forwards the PlatformException to IncidentLogger and still calls
+//     plugin.initialize on the Asia/Jerusalem fallback.
+//   * initializeNotification() / updateNotification() — early-return
+//     when supportsReminderSettings() is false; assert no scheduling
+//     calls reach the plugin.
+//   * scheduleNotification() — direct call exercises the cross-platform
+//     scheduling path against the iOS plugin variant.
+//   * cancelNotifications(id) / cancelNotifications(null) — both reach
+//     plugin.cancel / plugin.cancelAll on iOS.
+//
+// Explicitly NOT exercised (out of scope for Phase 10A):
+//   * cancelNotifications(null, cancelWorker: true) — Workmanager has no
+//     iOS implementation; the unit test stubs WorkmanagerPlatform.instance
+//     to verify the call, but exercising it through the real iOS binding
+//     surfaces no additional behavior. Reserved for a future ADR if
+//     iOS Workmanager substitute (e.g. background-fetch) is ever wired.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
+import 'package:mazilon/pages/notifications/notification_service.dart';
+import 'package:mazilon/util/logger_service.dart';
+// ignore: depend_on_referenced_packages
+import 'package:workmanager_platform_interface/workmanager_platform_interface.dart';
+
+// iOS-side Workmanager safety net. The workmanager package has no iOS
+// implementation, so `WorkmanagerPlatform.instance` defaults to a stub that
+// throws `UnimplementedError`. The Android sibling subclasses
+// `WorkmanagerAndroid` to defeat the binding's swap-back; iOS has no
+// equivalent platform class to extend, but it also has no swap-back
+// mechanism — so the simple `WorkmanagerPlatform` subclass is sufficient.
+class _NoopWorkmanagerIOS extends WorkmanagerPlatform {
+  _NoopWorkmanagerIOS._() : super();
+  static final _NoopWorkmanagerIOS _shared = _NoopWorkmanagerIOS._();
+  final List<String> calls = [];
+
+  static _NoopWorkmanagerIOS register() {
+    WorkmanagerPlatform.instance = _shared;
+    _shared.calls.clear();
+    return _shared;
+  }
+
+  @override
+  Future<void> cancelAll() async {
+    calls.add('cancelAll');
+  }
+}
+
+class _DummyLocale implements AppLocalizations {
+  @override
+  String get noPermissionAllowedText => 'no permission';
+
+  @override
+  String notifyOnscheduledNotification(Object time) =>
+      'You will be notified at $time';
+
+  @override
+  String get localeName => 'en';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => '';
+}
+
+class _RecordingLogger implements IncidentLoggerService {
+  final List<Object?> captured = [];
+
+  @override
+  Future<void> captureLog(dynamic exception,
+      {StackTrace? stackTrace, dynamic exceptionData}) async {
+    captured.add(exception);
+  }
+
+  @override
+  Future<void> initializeSentry(Widget app) async {}
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const localNotifChannel =
+      MethodChannel('dexterous.com/flutter/local_notifications');
+  const timezoneChannel = MethodChannel('flutter_timezone');
+  const toastChannel = MethodChannel('PonnamKarthik/fluttertoast');
+
+  late List<MethodCall> localNotifCalls;
+  late Object? timezoneError;
+  late String timezoneId;
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    GetIt.instance.registerSingleton<IncidentLoggerService>(_RecordingLogger());
+
+    // Clear the static `_isInitialized` guard so init() runs its body each
+    // test — mirrors the Android sibling's setUp (PR #266 review finding
+    // 3/4).
+    NotificationsService.resetForTest();
+
+    // Register the iOS platform implementation so the
+    // `resolvePlatformSpecificImplementation` chain inside the plugin works
+    // without a `LateInitializationError`. The Android sibling does the
+    // analogous `AndroidFlutterLocalNotificationsPlugin.registerWith()`.
+    IOSFlutterLocalNotificationsPlugin.registerWith();
+
+    // Install the iOS workmanager safety net. None of the iOS-arm tests in
+    // this file call `cancelNotifications(..., cancelWorker: true)`, but a
+    // future maintainer who adds one should get a recorded call rather than
+    // an `UnimplementedError`.
+    _NoopWorkmanagerIOS.register();
+
+    localNotifCalls = [];
+    timezoneError = null;
+    timezoneId = 'America/Los_Angeles';
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      ..setMockMethodCallHandler(timezoneChannel, (call) async {
+        if (call.method == 'getLocalTimezone') {
+          if (timezoneError != null) throw timezoneError!;
+          return timezoneId;
+        }
+        return null;
+      })
+      ..setMockMethodCallHandler(localNotifChannel, (call) async {
+        localNotifCalls.add(call);
+        // The iOS plugin's permission-request method name is
+        // `requestPermissions` (Darwin idiom); Android's is
+        // `requestNotificationsPermission`. We handle both for robustness
+        // across plugin versions.
+        switch (call.method) {
+          case 'initialize':
+          case 'requestPermissions':
+          case 'requestNotificationsPermission':
+          case 'requestExactAlarmsPermission':
+          case 'canScheduleExactAlarms':
+          case 'areNotificationsEnabled':
+            return true;
+          default:
+            return null;
+        }
+      })
+      ..setMockMethodCallHandler(toastChannel, (call) async => true);
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      ..setMockMethodCallHandler(timezoneChannel, null)
+      ..setMockMethodCallHandler(localNotifChannel, null)
+      ..setMockMethodCallHandler(toastChannel, null);
+    await GetIt.instance.reset();
+  });
+
+  group('supportsReminderSettings on real iOS binding', () {
+    testWidgets('defaultTargetPlatform is iOS under macos-14 + iOS sim',
+        (tester) async {
+      expect(defaultTargetPlatform, TargetPlatform.iOS,
+          reason:
+              'this file is expected to run on an iOS simulator; if defaultTargetPlatform is not iOS, the CI job targeted the wrong device');
+    });
+
+    testWidgets('returns false on iOS (no override)', (tester) async {
+      expect(NotificationsService.supportsReminderSettings(), isFalse,
+          reason: 'iOS is intentionally not a reminder-settings platform — '
+              'the function gates initializeNotification/updateNotification');
+    });
+
+    testWidgets('returns false when isWebOverride=true regardless of platform',
+        (tester) async {
+      expect(
+          NotificationsService.supportsReminderSettings(isWebOverride: true),
+          isFalse);
+    });
+  });
+
+  group('init() on iOS', () {
+    testWidgets('happy path reaches plugin.initialize via Darwin settings',
+        (tester) async {
+      await NotificationsService.init();
+      expect(localNotifCalls.any((c) => c.method == 'initialize'), isTrue,
+          reason: 'init() must reach plugin.initialize on iOS');
+    });
+
+    testWidgets('second call short-circuits via _isInitialized',
+        (tester) async {
+      await NotificationsService.init();
+      localNotifCalls.clear();
+      await NotificationsService.init();
+      expect(
+          localNotifCalls.where((c) => c.method == 'initialize').toList(),
+          isEmpty,
+          reason:
+              'idempotency: second init() should not reach plugin.initialize');
+    });
+
+    testWidgets(
+        'catch branch on iOS forwards PlatformException to IncidentLogger and still initializes plugin',
+        (tester) async {
+      // setUp already called resetForTest() so _isInitialized is false here —
+      // the init() body WILL run and the timezone throw will reach the
+      // catch branch.
+      timezoneError =
+          PlatformException(code: 'IOS_TZ_FAIL', message: 'simulated');
+
+      await NotificationsService.init();
+
+      final logger =
+          GetIt.instance<IncidentLoggerService>() as _RecordingLogger;
+      expect(
+        logger.captured
+            .any((e) => e is PlatformException && e.code == 'IOS_TZ_FAIL'),
+        isTrue,
+        reason:
+            'iOS catch branch must forward IOS_TZ_FAIL PlatformException to IncidentLogger',
+      );
+      expect(
+        localNotifCalls.any((c) => c.method == 'initialize'),
+        isTrue,
+        reason:
+            'iOS catch branch must still call plugin.initialize on the Asia/Jerusalem fallback',
+      );
+    });
+  });
+
+  group('initializeNotification / updateNotification iOS early-return', () {
+    testWidgets(
+        'initializeNotification() early-returns on iOS — no scheduling reaches the plugin',
+        (tester) async {
+      await NotificationsService.init();
+      localNotifCalls.clear();
+
+      await NotificationsService.initializeNotification(
+        const ['quote A'],
+        9,
+        15,
+        (s) => 'msg $s',
+        _DummyLocale(),
+      );
+      // The early-return path must not reach permission, schedule, or toast.
+      // (showToast itself goes via the fluttertoast channel which we mock
+      // separately; the assertion here is specifically about the plugin
+      // channel.)
+      expect(
+        localNotifCalls.any((c) =>
+            c.method == 'requestNotificationsPermission' ||
+            c.method == 'requestPermissions' ||
+            c.method == 'zonedSchedule'),
+        isFalse,
+        reason:
+            'iOS path must early-return before any plugin scheduling call',
+      );
+    });
+  });
+
+  group('scheduleNotification on iOS (direct call, bypasses guard)', () {
+    testWidgets('reaches plugin.zonedSchedule against the iOS binding',
+        (tester) async {
+      await NotificationsService.init();
+      localNotifCalls.clear();
+
+      await NotificationsService.scheduleNotification(
+        const TimeOfDay(hour: 0, minute: 0),
+        '90',
+        'Living Positively reminder',
+      );
+
+      expect(
+        localNotifCalls.any((c) => c.method == 'zonedSchedule'),
+        isTrue,
+        reason:
+            'scheduleNotification must reach plugin.zonedSchedule on iOS — '
+            'production safety-plan flow depends on this',
+      );
+    });
+  });
+
+  group('cancelNotifications on iOS', () {
+    testWidgets('cancelNotifications(id) reaches plugin.cancel',
+        (tester) async {
+      await NotificationsService.init();
+      localNotifCalls.clear();
+      await NotificationsService.cancelNotifications(42);
+      expect(localNotifCalls.any((c) => c.method == 'cancel'), isTrue);
+    });
+
+    testWidgets(
+        'cancelNotifications(null) reaches plugin.cancelAll without touching workmanager',
+        (tester) async {
+      await NotificationsService.init();
+      localNotifCalls.clear();
+
+      await NotificationsService.cancelNotifications(null);
+
+      expect(localNotifCalls.any((c) => c.method == 'cancelAll'), isTrue);
+    });
+  });
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -101,58 +101,106 @@ Future<void> refreshReminderForLocaleChange({
   await updateNotifications();
 }
 
-Future<void> initializeApp() async {
+// Phase 10B (ADR-005 § B): `firebaseInitializer` is a dependency-injection
+// seam used only by tests (`integration_test/bootstrap_full_test.dart`).
+// Production callers (`bootstrapApp` below) omit it and accept the default
+// `Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform)`
+// — behavior-preserving by construction.
+Future<void> initializeApp({
+  Future<void> Function()? firebaseInitializer,
+  void Function()? locatorSetup,
+}) async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  await (firebaseInitializer ??
+      () => Firebase.initializeApp(
+          options: DefaultFirebaseOptions.currentPlatform))();
 
-  setupLocator();
+  (locatorSetup ?? setupLocator)();
+}
+
+/// Test seam for `main()`. Performs platform binding + Firebase init +
+/// service-locator setup + (on non-web) Workmanager init, then returns the
+/// root widget tree. `main()` only adds the `IncidentLoggerService.
+/// initializeSentry(...)` call (which itself calls `runApp`); a test that
+/// calls `bootstrapApp()` directly can pump the returned widget through the
+/// test binding without going through `runApp`.
+///
+/// Named parameters are dependency-injection seams used by
+/// `integration_test/bootstrap_full_test.dart`. Production callers (`main()`
+/// below) omit them and accept defaults that exactly match the previous
+/// pre-extraction body — behavior-preserving by construction.
+///
+/// Per ADR-005 § B, this extraction is the **fourth sanctioned production-
+/// code exception** to the no-production-changes guard rail of the coverage
+/// initiative, alongside:
+///   1. ADR-001 Round 1 — `firestore` named-param injection on 14 helpers
+///      in `firebase_functions.dart`.
+///   2. ADR-002 PR #266 — `@visibleForTesting
+///      NotificationsService.resetForTest()`.
+///   3. ADR-004 Round 9 — `firestore` injection extended to 29 more helpers.
+/// All four share the same shape: narrow, mechanical, behaviour-preserving
+/// for production paths.
+Future<Widget> bootstrapApp({
+  Future<void> Function()? firebaseInitializer,
+  void Function()? locatorSetup,
+  void Function()? workmanagerInitializer,
+}) async {
+  await initializeApp(
+    firebaseInitializer: firebaseInitializer,
+    locatorSetup: locatorSetup,
+  );
+
+  // Initialize Workmanager only on mobile platforms (not web). Preserves the
+  // fire-and-forget shape of the original `main()` — `Workmanager().initialize`
+  // returns `Future<void>` but is intentionally not awaited so the rest of
+  // bootstrap can proceed in parallel.
+  if (!kIsWeb) {
+    (workmanagerInitializer ??
+        () {
+          Workmanager().initialize(
+            callbackDispatcher,
+            isInDebugMode: false,
+          );
+        })();
+  }
+
+  return MultiProvider(
+    providers: [
+      for (int i = 0; i < checkboxCollectionNames.length; i++)
+        // Initialize the checkbox models
+
+        // Initialize the phonePageData provider
+        ChangeNotifierProvider(
+          create: (context) => PhonePageData(
+              key: "PhonePage",
+              phoneNames: [],
+              phoneNumbers: [],
+              header: "", // Blank for unknown field
+              subTitle: "", // Blank for unknown field
+              midTitle: "", // Blank for unknown field
+              phoneNameTitle: "", // Blank for unknown field
+              phoneNumberTitle: "", // Blank for unknown field
+              savedPhoneNames: [], // Assuming empty list for unknown
+              savedPhoneNumbers: [], // Assuming empty list for unknown
+              phoneDescription: [] // Assuming empty list for unknown
+              )
+            ..loadItemsFromPrefs(), // Initialize phonePageData
+        ),
+
+      // Initialize the APP information provider
+      ChangeNotifierProvider(create: (context) => AppInformation()),
+      // Initialize the User information provider
+      ChangeNotifierProvider(create: (context) => UserInformation()),
+    ],
+    child: MyApp(),
+  );
 }
 
 void main() async {
-  await initializeApp();
-
-  IncidentLoggerService sentryService = GetIt.instance<IncidentLoggerService>();
-
-  // Initialize Workmanager only on mobile platforms (not web)
-  if (!kIsWeb) {
-    Workmanager().initialize(
-      callbackDispatcher,
-      isInDebugMode: false,
-    );
-  }
-
-  await sentryService.initializeSentry(
-    MultiProvider(
-      providers: [
-        for (int i = 0; i < checkboxCollectionNames.length; i++)
-          // Initialize the checkbox models
-
-          // Initialize the phonePageData provider
-          ChangeNotifierProvider(
-            create: (context) => PhonePageData(
-                key: "PhonePage",
-                phoneNames: [],
-                phoneNumbers: [],
-                header: "", // Blank for unknown field
-                subTitle: "", // Blank for unknown field
-                midTitle: "", // Blank for unknown field
-                phoneNameTitle: "", // Blank for unknown field
-                phoneNumberTitle: "", // Blank for unknown field
-                savedPhoneNames: [], // Assuming empty list for unknown
-                savedPhoneNumbers: [], // Assuming empty list for unknown
-                phoneDescription: [] // Assuming empty list for unknown
-                )
-              ..loadItemsFromPrefs(), // Initialize phonePageData
-          ),
-
-        // Initialize the APP information provider
-        ChangeNotifierProvider(create: (context) => AppInformation()),
-        // Initialize the User information provider
-        ChangeNotifierProvider(create: (context) => UserInformation()),
-      ],
-      child: MyApp(),
-    ),
-  );
+  final app = await bootstrapApp();
+  final IncidentLoggerService sentryService =
+      GetIt.instance<IncidentLoggerService>();
+  await sentryService.initializeSentry(app);
 }
 
 class MyApp extends StatefulWidget {

--- a/scripts/check_aggregate_coverage.dart
+++ b/scripts/check_aggregate_coverage.dart
@@ -1,10 +1,14 @@
 // Aggregate coverage gate for Mazilon (ADR-003 Phase 8, ratcheted by
-// ADR-004 Phase 9).
+// ADR-004 Phase 9; iOS input added under ADR-005 § A, Phase 10A).
 //
-// Reads TWO pre-merged lcov inputs:
-//   coverage/lcov.info        — produced by the build-android job (unit tests +
-//                               dart-define MixPanel merge; see ADR-001)
-//   coverage/integration.info — produced by the integration-test job (ADR-002)
+// Reads THREE pre-merged lcov inputs:
+//   coverage/lcov.info            — produced by the build-android job (unit
+//                                   tests + dart-define MixPanel merge; see
+//                                   ADR-001)
+//   coverage/integration.info     — produced by the integration-test job
+//                                   (ADR-002)
+//   coverage/integration_ios.info — produced by the integration-test-ios job
+//                                   (ADR-005 § A, Phase 10A)
 //
 // Merges them via parseLcovInputs (max hit-count per line, same semantics as
 // scripts/merge_lcov.dart) and enforces a single GLOBAL floor on the union
@@ -20,16 +24,17 @@
 // check_integration_coverage.dart (integration). Re-enforcing them here
 // would produce duplicate failures for regressions already caught upstream.
 //
-// Usage (CI — after both upstream jobs complete and artifacts are downloaded):
+// Usage (CI — after all upstream jobs complete and artifacts are downloaded):
 //   dart run scripts/check_aggregate_coverage.dart
 //
 // Exit codes:
 //   0  aggregate global floor met
 //   1  aggregate global floor not met
-//   2  either coverage/lcov.info or coverage/integration.info is absent —
-//      treated as a CI-configuration error rather than a coverage regression
-//      so the message is unambiguous (same pattern as
-//      check_integration_coverage.dart exit-2 for the integration lcov).
+//   2  any of coverage/lcov.info, coverage/integration.info, or
+//      coverage/integration_ios.info is absent — treated as a CI-configuration
+//      error rather than a coverage regression so the message is unambiguous
+//      (same pattern as check_integration_coverage.dart exit-2 for the
+//      integration lcov).
 //
 // Floor derivation:
 //   ADR-003 (Phase 8) — original 85% floor:
@@ -45,6 +50,13 @@
 //     Aggregate estimate: 5963 / 6493 = 91.84%
 //     Floor = 91.84% − 3.0 pt headroom ≈ 88.84% → rounded to 89%
 //     The 3 pt cushion matches every prior ratchet step.
+//
+//   ADR-005 § A (Phase 10A) — iOS input added without ratchet:
+//     The iOS integration lcov can only raise the union's hit-count (max
+//     per line), never lower it, so the existing 89% floor stays safe and
+//     the headroom only grows. A future ratchet to track the iOS-inclusive
+//     baseline is deferred until the iOS suite covers more than the single
+//     notifications_schedule_ios_test.dart file.
 
 import 'dart:io';
 
@@ -52,6 +64,7 @@ import '_lcov_parser.dart';
 
 const _unitLcovPath = 'coverage/lcov.info';
 const _integrationLcovPath = 'coverage/integration.info';
+const _iosIntegrationLcovPath = 'coverage/integration_ios.info';
 
 const double _aggregateFloor = 89.0; // ADR-004 (Phase 9 ratchet)
 
@@ -63,32 +76,40 @@ const _excludePatterns = <String>[
 ];
 
 void main(List<String> args) {
-  // Exit 2 if either input is absent — CI-configuration error, not a
-  // coverage regression. Check both before emitting any output so the
-  // diagnostic is unambiguous.
+  // Exit 2 if any input is absent — CI-configuration error, not a coverage
+  // regression. Check all three before emitting any output so the diagnostic
+  // is unambiguous.
   final missing = <String>[];
   if (!File(_unitLcovPath).existsSync()) missing.add(_unitLcovPath);
   if (!File(_integrationLcovPath).existsSync())
     missing.add(_integrationLcovPath);
+  if (!File(_iosIntegrationLcovPath).existsSync())
+    missing.add(_iosIntegrationLcovPath);
 
   if (missing.isNotEmpty) {
     stderr
       ..writeln('FATAL: the following lcov inputs are missing:')
       ..writeln('  ${missing.join('\n  ')}')
       ..writeln('')
-      ..writeln('Expected both files to be present in the coverage-aggregate')
-      ..writeln('job — did the artifact-download steps succeed?')
+      ..writeln('Expected all three files to be present in the')
+      ..writeln('coverage-aggregate job — did the artifact-download steps')
+      ..writeln('succeed?')
       ..writeln('')
       ..writeln('  $_unitLcovPath is produced by the build-android job')
       ..writeln('    (artifact: coverage-lcov)')
       ..writeln(
           '  $_integrationLcovPath is produced by the integration-test job')
-      ..writeln('    (artifact: coverage-integration-lcov)');
+      ..writeln('    (artifact: coverage-integration-lcov)')
+      ..writeln('  $_iosIntegrationLcovPath is produced by the')
+      ..writeln('    integration-test-ios job')
+      ..writeln('    (artifact: coverage-integration-ios-lcov)');
     exit(2);
   }
 
-  // Merge both lcovs (max hit-count per line, same semantics as merge_lcov.dart).
-  final merged = parseLcovInputs([_unitLcovPath, _integrationLcovPath]);
+  // Merge all three lcovs (max hit-count per line, same semantics as
+  // merge_lcov.dart).
+  final merged = parseLcovInputs(
+      [_unitLcovPath, _integrationLcovPath, _iosIntegrationLcovPath]);
 
   // Apply exclude list (identical to check_coverage.dart).
   final excludes =
@@ -115,7 +136,9 @@ void main(List<String> args) {
   stdout
     ..writeln(
         '======= Mazilon Aggregate Coverage Gate (ADR-003/ADR-004) =======')
-    ..writeln('Inputs:   $_unitLcovPath (unit) + $_integrationLcovPath (intg)')
+    ..writeln('Inputs:   $_unitLcovPath (unit) + '
+        '$_integrationLcovPath (intg) + '
+        '$_iosIntegrationLcovPath (iOS intg)')
     ..writeln('Files:    ${filtered.length} (excluded: ${excluded.length})')
     ..writeln('Lines:    $totalHit / $totalLines = '
         '${aggregatePct.toStringAsFixed(2)}%')

--- a/scripts/check_integration_coverage.dart
+++ b/scripts/check_integration_coverage.dart
@@ -2,8 +2,9 @@
 // `lib/main.dart` floor raised under ADR-005 § B, Phase 10B).
 //
 // Sibling of scripts/check_coverage.dart. Reads coverage/integration.info
-// (produced by `flutter test integration_test --coverage --coverage-path
-// coverage/integration.info`) and enforces ONLY the per-file floors below.
+// (produced by the Android integration-test job's explicit test-file list with
+// `--coverage --coverage-path coverage/integration.info`) and enforces ONLY
+// the per-file floors below.
 // Global coverage is owned by the unit pipeline (`scripts/check_coverage.dart`)
 // and the aggregate gate (`scripts/check_aggregate_coverage.dart`); this gate
 // intentionally does NOT check global so that emulator-class flakes in the
@@ -52,10 +53,9 @@ void main(List<String> args) {
   if (!lcovFile.existsSync()) {
     stderr
       ..writeln('FATAL: coverage/integration.info not found.')
+      ..writeln('  Expected the integration-test job to have produced it via:')
       ..writeln(
-          '  Expected the integration-test job to have produced it via:')
-      ..writeln(
-          '    flutter test integration_test --coverage --coverage-path coverage/integration.info')
+          '    flutter test <Android integration files> --coverage --coverage-path coverage/integration.info')
       ..writeln(
           '  If you are running locally and have no emulator attached, this is')
       ..writeln(

--- a/scripts/check_integration_coverage.dart
+++ b/scripts/check_integration_coverage.dart
@@ -1,19 +1,23 @@
-// Coverage gate for the Mazilon integration_test/ pipeline (ADR-002, Phase 7).
+// Coverage gate for the Mazilon integration_test/ pipeline (ADR-002, Phase 7;
+// `lib/main.dart` floor raised under ADR-005 § B, Phase 10B).
 //
 // Sibling of scripts/check_coverage.dart. Reads coverage/integration.info
 // (produced by `flutter test integration_test --coverage --coverage-path
 // coverage/integration.info`) and enforces ONLY the per-file floors below.
-// Global coverage is owned by the unit pipeline (`scripts/check_coverage.dart`);
-// this gate intentionally does NOT check it so that emulator-class flakes in
-// the integration job cannot pull the global gate below 82%.
+// Global coverage is owned by the unit pipeline (`scripts/check_coverage.dart`)
+// and the aggregate gate (`scripts/check_aggregate_coverage.dart`); this gate
+// intentionally does NOT check global so that emulator-class flakes in the
+// integration job cannot pull the unit pipeline's 85% global floor below
+// threshold.
 //
-// Per ADR-002 § "Per-file floors in scripts/check_integration_coverage.dart":
+// **Current floors** (see `_floors` map below for the authoritative values —
+// this comment is illustrative and is updated when the map changes):
 //
 //   const _floors = <String, double>{
-//     'lib/main.dart': 50.0,
-//     'lib/pages/WellnessTools/player.dart': 60.0,
-//     'lib/util/logger_service.dart': 60.0,
-//     'lib/pages/notifications/notification_service.dart': 85.0,
+//     'lib/main.dart': 65.0,                                         // ADR-005 § B (was 50.0 under ADR-002)
+//     'lib/pages/WellnessTools/player.dart': 60.0,                   // ADR-002
+//     'lib/util/logger_service.dart': 60.0,                          // ADR-002
+//     'lib/pages/notifications/notification_service.dart': 85.0,     // ADR-002
 //   };
 //
 // Exit codes:
@@ -26,8 +30,18 @@ import 'dart:io';
 
 import '_lcov_parser.dart';
 
+// Phase 10B (ADR-005 § B) raised `lib/main.dart` from 50.0 → 65.0 after the
+// `bootstrapApp()` extraction made the bootstrap path reachable from the
+// new `integration_test/bootstrap_full_test.dart`. The smoke test already
+// covered MyApp; the full test additionally exercises the lines that
+// build the widget tree (the MultiProvider construction + the optional
+// dependency-injection branches) plus the extracted `initializeApp` body.
+// callbackDispatcher (lines 42-89) stays uncovered — foreground integration
+// tests cannot trigger a Workmanager background entry-point. The 65% floor
+// is set below the expected ~75% so the gate tolerates incidental drift
+// from new lines added to MyApp in future feature work.
 const _floors = <String, double>{
-  'lib/main.dart': 50.0,
+  'lib/main.dart': 65.0,
   'lib/pages/WellnessTools/player.dart': 60.0,
   'lib/util/logger_service.dart': 60.0,
   'lib/pages/notifications/notification_service.dart': 85.0,

--- a/scripts/check_ios_integration_coverage.dart
+++ b/scripts/check_ios_integration_coverage.dart
@@ -1,0 +1,82 @@
+// Coverage gate for the Mazilon iOS integration_test/ pipeline
+// (ADR-005 § A, Phase 10A).
+//
+// Sibling of scripts/check_integration_coverage.dart. Reads
+// coverage/integration_ios.info (produced by `flutter test integration_test/
+// notifications_schedule_ios_test.dart --coverage --coverage-path
+// coverage/integration_ios.info` in the macos-14 `integration-test-ios` job)
+// and enforces ONLY the per-file floors below.
+//
+// Global coverage is owned by the unit pipeline (`scripts/check_coverage.dart`)
+// and the aggregate gate (`scripts/check_aggregate_coverage.dart`). This iOS
+// gate intentionally does NOT check global — it would be misleading: this
+// invocation runs only one test file, so its lcov is sparse by design.
+//
+// The 60% floor on `lib/pages/notifications/notification_service.dart` under
+// the iOS invocation alone is sized to:
+//   - Catch a regression where the iOS test stops exercising the file
+//     meaningfully (e.g. setup change accidentally skips the body of every
+//     testWidgets block) — that would push coverage below 60% immediately.
+//   - Tolerate the iOS surface being structurally narrower than Android
+//     (no Workmanager arm, no Android permission flow, no
+//     androidScheduleMode-only code paths).
+//
+// Exit codes:
+//   0  per-file floors met
+//   1  one or more floors not met (or files missing from lcov)
+//   2  coverage/integration_ios.info is missing — fatal, treated as a CI-
+//      config error rather than a coverage regression.
+
+import 'dart:io';
+
+import '_lcov_parser.dart';
+
+const _floors = <String, double>{
+  'lib/pages/notifications/notification_service.dart': 60.0,
+};
+
+void main(List<String> args) {
+  final lcovFile = File('coverage/integration_ios.info');
+  if (!lcovFile.existsSync()) {
+    stderr
+      ..writeln('FATAL: coverage/integration_ios.info not found.')
+      ..writeln(
+          '  Expected the integration-test-ios job to have produced it via:')
+      ..writeln('    flutter test integration_test/'
+          'notifications_schedule_ios_test.dart \\')
+      ..writeln('      --coverage \\')
+      ..writeln('      --coverage-path coverage/integration_ios.info \\')
+      ..writeln('      -d "<iPhone simulator UDID>"')
+      ..writeln('  If you are running locally without an iOS simulator '
+          'attached, this is expected — the file is generated only by the '
+          'macos-14 CI integration-test-ios job.');
+    exit(2);
+  }
+
+  final stats = parseLcov(lcovFile);
+
+  final result = enforceFloors(
+    stats: stats,
+    floors: _floors,
+    label: 'iOS PER-FILE',
+  );
+
+  stdout
+    ..writeln(
+        '===== Mazilon iOS Integration Coverage Gate (ADR-005 § A) =====')
+    ..writeln('Files inspected: ${_floors.length}')
+    ..writeln(result.reportLines.join('\n'))
+    ..writeln(
+        '===============================================================');
+
+  if (result.failures.isEmpty) {
+    stdout.writeln('PASS: all iOS integration-test per-file floors met.');
+    exit(0);
+  } else {
+    stderr.writeln('FAIL: iOS integration-test per-file floors not met:');
+    for (final f in result.failures) {
+      stderr.writeln('  - $f');
+    }
+    exit(1);
+  }
+}

--- a/scripts/check_ios_integration_coverage.dart
+++ b/scripts/check_ios_integration_coverage.dart
@@ -4,7 +4,7 @@
 // Sibling of scripts/check_integration_coverage.dart. Reads
 // coverage/integration_ios.info (produced by `flutter test integration_test/
 // notifications_schedule_ios_test.dart --coverage --coverage-path
-// coverage/integration_ios.info` in the macos-14 `integration-test-ios` job)
+// coverage/integration_ios.info` in the macos-15 `integration-test-ios` job)
 // and enforces ONLY the per-file floors below.
 //
 // Global coverage is owned by the unit pipeline (`scripts/check_coverage.dart`)
@@ -49,7 +49,7 @@ void main(List<String> args) {
       ..writeln('      -d "<iPhone simulator UDID>"')
       ..writeln('  If you are running locally without an iOS simulator '
           'attached, this is expected — the file is generated only by the '
-          'macos-14 CI integration-test-ios job.');
+          'macos-15 CI integration-test-ios job.');
     exit(2);
   }
 
@@ -62,8 +62,7 @@ void main(List<String> args) {
   );
 
   stdout
-    ..writeln(
-        '===== Mazilon iOS Integration Coverage Gate (ADR-005 § A) =====')
+    ..writeln('===== Mazilon iOS Integration Coverage Gate (ADR-005 § A) =====')
     ..writeln('Files inspected: ${_floors.length}')
     ..writeln(result.reportLines.join('\n'))
     ..writeln(


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document the Phase 10 coverage plan that codifies ADR-005’s macOS/iOS/web initiatives and explains how the new CI/coverage tooling and tests fulfill the updated aggregate goals. Coordinate the CI workflows, gate scripts, and integration tests with the <code>bootstrapApp()</code> refactor so that the platform-specific paths and aggregate boundaries are exercised and enforced end-to-end.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/270?tool=ast&topic=Bootstrap+coverage>Bootstrap coverage</a>
        </td><td>Enable tests to reach the remaining uncovered bootstrap flow by extracting <code>bootstrapApp()</code> plus adjustable dependency seams, raising the <code>lib/main.dart</code> per-file floor, and exercising the new seam via <code>integration_test/bootstrap_full_test.dart</code> and the iOS-specific <code>notifications_schedule_ios_test.dart</code> integration suite.<details><summary>Modified files (4)</summary><ul><li>integration_test/bootstrap_full_test.dart</li>
<li>integration_test/notifications_schedule_ios_test.dart</li>
<li>lib/main.dart</li>
<li>scripts/check_integration_coverage.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>ci(integration): split...</td><td>May 26, 2026</td></tr>
<tr><td>lubacareer@gmail.com</td><td>Merge main into suppor...</td><td>May 04, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/270?tool=ast&topic=Coverage+docs>Coverage docs</a>
        </td><td>Capture the Phase 10 strategy and risk/mitigation narrative so reviewers understand why the ADR, coverage plan, and Round 10 status updates codify the new macOS-cost framing, coverage gaps, and remaining deferred work. Reference ADR-005’s rationale, execution sequence, uncovered gaps, and aggregate-floor recalculation alongside the Round 10 doc refresh that records the post-correction numbers.<details><summary>Modified files (3)</summary><ul><li>docs/adr/ADR-005-phase-10-macos-runner-ios-and-web-coverage.md</li>
<li>docs/coverage-phase10-plan.md</li>
<li>docs/coverage-status.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>`bootstrapApp()` extra...</td><td>May 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/270?tool=ast&topic=CI+coverage+gates>CI coverage gates</a>
        </td><td>Strengthen the coverage gates by adding the iOS simulator CI job, the web telemetry job, and the aggregate merge updates, and ensure the new iOS artifact is validated via <code>scripts/check_ios_integration_coverage.dart</code> while the aggregate gate now merges all CI lcov inputs so the 3+ job floor remains enforced.<details><summary>Modified files (3)</summary><ul><li>.github/workflows/main.yml</li>
<li>scripts/check_aggregate_coverage.dart</li>
<li>scripts/check_ios_integration_coverage.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>update ci to macos-26</td><td>May 26, 2026</td></tr>
<tr><td>dekel@tovli.co.il</td><td>Merge branch 'main' in...</td><td>July 05, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/270?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>