### PR TITLE
Review uncommitted RTL accessibility changes

### DIFF
--- a/lib/main_menu_dialog.dart
+++ b/lib/main_menu_dialog.dart
@@ -95,8 +95,6 @@ void showMainMenuDialog({
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   Row(
-                    textDirection:
-                        isRtl ? TextDirection.ltr : TextDirection.rtl,
                     children: [
                       IconButton(
                         key: const Key('mainMenuCloseButton'),
@@ -107,9 +105,7 @@ void showMainMenuDialog({
                       ),
                       Expanded(
                         child: Align(
-                          alignment: isRtl
-                              ? Alignment.centerRight
-                              : Alignment.centerLeft,
+                          alignment: AlignmentDirectional.centerStart,
                           child: TextButton(
                             child: Row(
                               mainAxisSize: MainAxisSize.min,

--- a/lib/pages/positive.dart
+++ b/lib/pages/positive.dart
@@ -232,9 +232,7 @@ class _PositiveState extends LPExtendedState<Positive> {
                                 fontSize: 16.sp,
                                 fontWeight: FontWeight.bold,
                               ),
-                              appLocale!.textDirection == "rtl"
-                                  ? TextAlign.right
-                                  : TextAlign.left,
+                              TextAlign.start,
                               30,
                               3),
                         ),

--- a/lib/util/HomePage/inspirationalQuote.dart
+++ b/lib/util/HomePage/inspirationalQuote.dart
@@ -62,11 +62,9 @@ class _InspirationalQuoteState extends LPExtendedState<InspirationalQuote> {
         height: 120,
         child: Stack(
           children: [
-            Positioned(
-              top: 5, // Adjust the position as needed
-              left: appLocale.textDirection == "rtl" ? 5 : null,
-              right: appLocale.textDirection == "rtl" ? null : 5,
-
+            PositionedDirectional(
+              top: 5,
+              end: 5,
               // Tooltip owns the announced label; Semantics only adds the
               // `button` role so GestureDetector doesn't read as plain text.
               child: Semantics(
@@ -102,10 +100,10 @@ class _InspirationalQuoteState extends LPExtendedState<InspirationalQuote> {
                   const SizedBox(width: 10),
                   Expanded(
                     child: Padding(
-                      padding: EdgeInsets.fromLTRB(
-                        (appLocale.textDirection == "rtl" ? 30.0 : 0),
+                      padding: const EdgeInsetsDirectional.fromSTEB(
                         0,
-                        (appLocale.textDirection == "rtl" ? 0.0 : 30.0),
+                        0,
+                        30,
                         0,
                       ),
                       child: myAutoSizedText(
@@ -115,9 +113,7 @@ class _InspirationalQuoteState extends LPExtendedState<InspirationalQuote> {
                           color: appWhite,
                           fontSize: 24.sp,
                         ),
-                        appLocale!.textDirection == "rtl"
-                            ? TextAlign.right
-                            : TextAlign.left,
+                        TextAlign.start,
                         24,
                         4,
                       ),

--- a/test/MenuTest/Wellness/wellnessTools_test.dart
+++ b/test/MenuTest/Wellness/wellnessTools_test.dart
@@ -131,10 +131,14 @@ void main() {
       expect(menuDialogTop, greaterThanOrEqualTo(menuButtonBottom));
       expect(menuDialogTop - menuButtonBottom, lessThan(20));
       expect(menuDialogWidth, lessThanOrEqualTo(260));
-      expect(closeButtonLeft, lessThan(menuDialogLeft + menuDialogWidth / 2));
+      expect(
+        closeButtonLeft,
+        greaterThan(menuDialogLeft + menuDialogWidth / 2),
+        reason: 'RTL header controls should start from the right edge.',
+      );
       expect((closeButtonCenterY - aboutIconCenterY).abs(), lessThan(8));
     });
-    testWidgets('Header menu puts close button on the right in English',
+    testWidgets('Header menu puts close button on the left in English',
         (WidgetTester tester) async {
       tester.view.physicalSize = const Size(1200, 900);
       tester.view.devicePixelRatio = 1;
@@ -161,7 +165,10 @@ void main() {
       expect(menuDialogTop, greaterThanOrEqualTo(menuButtonBottom));
       expect(menuDialogTop - menuButtonBottom, lessThan(20));
       expect(
-          closeButtonLeft, greaterThan(menuDialogLeft + menuDialogWidth / 2));
+        closeButtonLeft,
+        lessThan(menuDialogLeft + menuDialogWidth / 2),
+        reason: 'LTR header controls should start from the left edge.',
+      );
     });
     testWidgets('Navigate from WellnessTools screen',
         (WidgetTester tester) async {

--- a/test/a11y/phase_c_rtl_test.dart
+++ b/test/a11y/phase_c_rtl_test.dart
@@ -1,0 +1,234 @@
+// Phase C (ADR-005) — RTL regression tests.
+//
+// Covers the directionality gaps catalogued in `docs/UX_GAPS.md` §1.4, §3.3,
+// §3.5, and §3.11. The previous implementations branched on
+// `appLocale.textDirection == "rtl"` to pick LTR/RTL `Positioned`, `EdgeInsets`,
+// `TextAlign`, and `Alignment` values. Phase C replaces those branches with
+// `PositionedDirectional`, `EdgeInsetsDirectional`, `TextAlign.start`, and
+// `AlignmentDirectional` so layouts inherit the ambient `Directionality` from
+// the MaterialApp locale.
+//
+// These tests pump real production widgets in both `en` and `he` locales and
+// assert (a) directional widgets are used in place of the old branches and (b)
+// the resulting global positions actually flip when the locale changes.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
+import 'package:mazilon/main_menu_dialog.dart';
+import 'package:mazilon/util/Form/formPagePhoneModel.dart';
+import 'package:mazilon/util/HomePage/inspirationalQuote.dart';
+import 'package:mazilon/util/userInformation.dart';
+
+import '../helpers/widget_test_scaffold.dart';
+
+PhonePageData _phoneData() => PhonePageData(
+      key: 'phone',
+      header: 'h',
+      subTitle: 's',
+      midTitle: 'm',
+      phoneNameTitle: 'n',
+      phoneNumberTitle: 'p',
+      phoneNames: const <String>[],
+      phoneNumbers: const <String>[],
+      savedPhoneNames: const <String>[],
+      savedPhoneNumbers: const <String>[],
+      phoneDescription: const <String>[],
+    );
+
+Widget _wrapQuote(List<String> quotes, {Locale locale = const Locale('en')}) {
+  return MaterialApp(
+    locale: locale,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: ScreenUtilInit(
+      designSize: const Size(360, 690),
+      builder: (context, _) => Scaffold(
+        body: Center(child: InspirationalQuote(quotes: quotes)),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('InspirationalQuote uses directional layout (UX_GAPS §1.4, §3.3)', () {
+    setUp(() => registerTestServices(locale: 'en'));
+    tearDown(resetTestServices);
+
+    testWidgets(
+        'PositionedDirectional + EdgeInsetsDirectional replace the isRtl branches',
+        (tester) async {
+      await tester.pumpWidget(_wrapQuote(const ['quote-one']));
+      await tester.pumpAndSettle();
+
+      // Phase C contract: the close button is positioned with
+      // PositionedDirectional(end:), not Positioned(left:/right:) branches.
+      expect(
+        find.byType(PositionedDirectional),
+        findsOneWidget,
+        reason:
+            'InspirationalQuote close button must use PositionedDirectional '
+            'so its trailing edge follows the ambient Directionality.',
+      );
+
+      // Phase C contract: the quote-text Padding uses EdgeInsetsDirectional,
+      // so the trailing padding flips with the locale instead of being baked
+      // into LTRB at construction time.
+      final paddings = tester.widgetList<Padding>(find.byType(Padding));
+      final directional = paddings.where(
+        (p) => p.padding is EdgeInsetsDirectional,
+      );
+      expect(
+        directional,
+        isNotEmpty,
+        reason:
+            'InspirationalQuote text wrapper must use EdgeInsetsDirectional '
+            'instead of EdgeInsets.fromLTRB keyed on isRtl.',
+      );
+    });
+
+    testWidgets(
+        'close button lands on the trailing edge in LTR (right side)',
+        (tester) async {
+      await tester.pumpWidget(_wrapQuote(const ['quote-one']));
+      await tester.pumpAndSettle();
+
+      final closeCenter = tester.getCenter(find.byIcon(Icons.close));
+      final quoteCenter = tester
+          .getCenter(find.byType(InspirationalQuote).first);
+      expect(
+        closeCenter.dx,
+        greaterThan(quoteCenter.dx),
+        reason: 'Close icon must sit on the right (trailing in LTR).',
+      );
+    });
+
+    testWidgets(
+        'close button flips to the trailing edge in RTL (left side)',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrapQuote(const ['quote-one'], locale: const Locale('he')),
+      );
+      await tester.pumpAndSettle();
+
+      final closeCenter = tester.getCenter(find.byIcon(Icons.close));
+      final quoteCenter = tester
+          .getCenter(find.byType(InspirationalQuote).first);
+      expect(
+        closeCenter.dx,
+        lessThan(quoteCenter.dx),
+        reason:
+            'Close icon must flip to the left in RTL (trailing in he). '
+            'If this fails, the close button is still pinned with Positioned '
+            'instead of PositionedDirectional.',
+      );
+    });
+  });
+
+  group('main_menu_dialog Row inherits ambient Directionality '
+      '(UX_GAPS §1.4, §3.11)', () {
+    setUp(() {
+      registerTestServices(locale: 'he');
+    });
+    tearDown(resetTestServices);
+
+    Future<void> openMenu(WidgetTester tester, Locale locale) async {
+      final user = UserInformation()
+        ..gender = 'other'
+        ..localeName = locale.languageCode;
+      await pumpWithProviders(
+        tester,
+        Builder(builder: (ctx) {
+          return Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                key: const Key('openMenu'),
+                onPressed: () {
+                  showMainMenuDialog(
+                    context: ctx,
+                    anchorContext: ctx,
+                    appLocale: AppLocalizations.of(ctx)!,
+                    userInformation: user,
+                    phonePageData: _phoneData(),
+                    changeLocale: (_) {},
+                    isWeb: false,
+                    onAboutPressed: () {},
+                    onNotificationsPressed: () {},
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          );
+        }),
+        userInformation: user,
+        locale: locale,
+        surfaceSize: const Size(1024, 800),
+      );
+      await tester.tap(find.byKey(const Key('openMenu')));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+        'header Row no longer pins an inverted textDirection in he locale',
+        (tester) async {
+      await openMenu(tester, const Locale('he'));
+
+      // The header Row that holds the close (X) button used to set
+      // `textDirection: isRtl ? LTR : RTL` (UX_GAPS §1.4). Phase C drops
+      // that override so the Row inherits the ambient Directionality (RTL
+      // in `he`). We assert by walking up from the close button to the
+      // first Row ancestor and confirming the override is null.
+      final closeFinder = find.byKey(const Key('mainMenuCloseButton'));
+      expect(closeFinder, findsOneWidget);
+
+      final rowAncestor = find.ancestor(
+        of: closeFinder,
+        matching: find.byType(Row),
+      );
+      expect(rowAncestor, findsWidgets);
+
+      final headerRow = tester.widget<Row>(rowAncestor.first);
+      expect(
+        headerRow.textDirection,
+        isNull,
+        reason:
+            'main_menu_dialog header Row must not override textDirection — '
+            'Phase C removed the inverted `isRtl ? LTR : RTL` branch.',
+      );
+    });
+
+    testWidgets(
+        'About label aligns to leading edge via AlignmentDirectional',
+        (tester) async {
+      await openMenu(tester, const Locale('he'));
+
+      // The Align wrapping the About TextButton previously branched on
+      // isRtl between centerLeft/centerRight. Phase C uses
+      // AlignmentDirectional.centerStart so the label tracks the ambient
+      // Directionality (start = right in RTL, left in LTR). Assert by
+      // walking every Align under the dialog Material — the directional
+      // Align is unique; TextButton/Material insert non-directional
+      // Aligns internally that we must skip.
+      final aligns = tester.widgetList<Align>(
+        find.descendant(
+          of: find.byKey(const Key('mainMenuDialog')),
+          matching: find.byType(Align),
+        ),
+      );
+      final directional = aligns
+          .where((a) => a.alignment == AlignmentDirectional.centerStart);
+      expect(
+        directional,
+        isNotEmpty,
+        reason:
+            'main_menu_dialog must wrap the About label in an Align with '
+            'AlignmentDirectional.centerStart instead of the isRtl ? '
+            'centerRight : centerLeft branch.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
# User description
**Findings**
- [Medium] `test/a11y/phase_c_rtl_test.dart` is still untracked, so if the current staged set is committed as-is, the new RTL regression coverage will be left out of the branch. The code changes in `lib/main_menu_dialog.dart`, `lib/pages/positive.dart`, and `lib/util/HomePage/inspirationalQuote.dart` are staged, but the companion test is not.
- [Low] `lib/pages/positive.dart` and `lib/util/HomePage/inspirationalQuote.dart` still contain existing analyzer warnings unrelated to this diff. I didn’t see a functional regression from them, but they will keep analyzer noise in the tree.

**Testing**
- `flutter test test/a11y/phase_c_rtl_test.dart` passed.
- `flutter test test/a11y/phase_c_rtl_test.dart test/main_menu_dialog_test.dart test/util/styles_test.dart` passed after ignoring an unrelated existing broken test entry.
- `dart analyze lib/main_menu_dialog.dart lib/pages/positive.dart lib/util/HomePage/inspirationalQuote.dart test/a11y/phase_c_rtl_test.dart` returned existing warnings only; no new errors from the RTL changes.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Shift the main menu header, positive page text, and inspirational quote widgets to rely on directional layout helpers so they inherit the ambient locale rather than branching on <code>isRtl</code>. Add RTL regression tests that exercise the updated dialog header and quote flows to ensure trailing-edge controls move with the locale.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/277?tool=ast&topic=RTL+Regression+Tests>RTL Regression Tests</a>
        </td><td>Add Phase C RTL regression tests that assert directional widgets and trailing-edge positions for the dialog header and inspirational quote and adjust the wellness tools expectations for LTR/RTL close-button placement.<details><summary>Modified files (2)</summary><ul><li>test/MenuTest/Wellness/wellnessTools_test.dart</li>
<li>test/a11y/phase_c_rtl_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>Fix Wellness menu dire...</td><td>May 28, 2026</td></tr>
<tr><td>lubacareer@gmail.com</td><td>Refine support navigat...</td><td>April 20, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/277?tool=ast&topic=RTL+Layout+Updates>RTL Layout Updates</a>
        </td><td>Align the main menu header, <code>Positive</code> text, and <code>InspirationalQuote</code> padding with <code>AlignmentDirectional</code>, <code>TextAlign.start</code>, and directional EdgeInsets so they follow the ambient locale instead of manual <code>isRtl</code> branching.<details><summary>Modified files (3)</summary><ul><li>lib/main_menu_dialog.dart</li>
<li>lib/pages/positive.dart</li>
<li>lib/util/HomePage/inspirationalQuote.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>Fix RTL layout regress...</td><td>May 28, 2026</td></tr>
<tr><td>lubacareer@gmail.com</td><td>Add language-dynamic c...</td><td>May 13, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/277?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>