### PR TITLE
Instrument iOS integration telemetry hangs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,6 +257,10 @@ jobs:
     # `coverage-aggregate.needs` AND restore the iOS branch in
     # check_aggregate_coverage.dart.
     runs-on: macos-15
+    # Telemetry must still be time-bounded. GitHub's default job timeout is
+    # 360 minutes, which lets a stuck `flutter test` monopolize the macOS
+    # runner long after the blocking gates have completed.
+    timeout-minutes: 60
     env:
       FIREBASE_OPTIONS_PATH: lib/util/Firebase/firebase_options.dart
       IOS_PODS_CACHE_VERSION: v1
@@ -325,6 +329,7 @@ jobs:
         # — pick the first "iPhone " device that is available. Avoid pinning
         # to a specific model so the job survives when GitHub rotates the
         # default Xcode/iOS-runtime bundle.
+        timeout-minutes: 10
         run: |
           DEVICE_LINE=$(xcrun simctl list devices available | grep -E '^\s+iPhone ' | head -n 1)
           DEVICE_ID=$(echo "$DEVICE_LINE" | awk -F '[()]' '{print $2}')
@@ -340,7 +345,7 @@ jobs:
           # bootstatus blocks until the sim is fully booted (springboard up).
           xcrun simctl bootstatus "$DEVICE_ID" -b
 
-      - name: Run iOS integration test
+      - name: Run iOS integration test with diagnostics
         # Notes on the invocation below (mirrors the Android job's design
         # rationale in the integration-test job above):
         #
@@ -364,9 +369,82 @@ jobs:
         # also re-adding integration-test-ios to coverage-aggregate.needs
         # and restoring the iOS branch in check_aggregate_coverage.dart.
         continue-on-error: true
+        timeout-minutes: 45
         run: |
-          flutter devices
-          flutter test integration_test/notifications_schedule_ios_test.dart --no-pub --coverage --coverage-path coverage/integration_ios.info --dart-define=SENTRY_DSN=https://test@dsn.example.local/0 -d "$DEVICE_ID"
+          mkdir -p ci-ios-diagnostics
+          {
+            echo "=== date ==="
+            date -u
+            echo
+            echo "=== selected simulator ==="
+            echo "$DEVICE_ID"
+            xcrun simctl list "$DEVICE_ID"
+            echo
+            echo "=== flutter devices -v ==="
+            flutter devices -v
+          } > ci-ios-diagnostics/preflight.txt 2>&1 || true
+
+          xcrun simctl spawn "$DEVICE_ID" log stream \
+            --style compact \
+            --level debug \
+            --predicate 'process == "Runner" OR process == "SpringBoard" OR eventMessage CONTAINS "Flutter" OR eventMessage CONTAINS "Observatory" OR eventMessage CONTAINS "VMService"' \
+            > ci-ios-diagnostics/simulator.log 2>&1 &
+          SIM_LOG_PID=$!
+
+          (
+            sleep 2400
+            {
+              echo "=== iOS test watchdog fired at 40 minutes ==="
+              date -u
+              echo
+              echo "=== process snapshot ==="
+              ps -axo pid,ppid,etime,command | grep -E 'flutter|dart|xcodebuild|simctl|Runner|ios-deploy' | grep -v grep || true
+              echo
+              echo "=== simulator state ==="
+              xcrun simctl list "$DEVICE_ID"
+            } > ci-ios-diagnostics/watchdog.txt 2>&1
+            xcrun simctl io "$DEVICE_ID" screenshot ci-ios-diagnostics/watchdog-screenshot.png > ci-ios-diagnostics/watchdog-screenshot.txt 2>&1 || true
+            mkdir -p ci-ios-diagnostics/DiagnosticReports
+            find ~/Library/Logs/DiagnosticReports -type f -mtime -1 -exec cp {} ci-ios-diagnostics/DiagnosticReports/ \; 2>/dev/null || true
+          ) &
+          WATCHDOG_PID=$!
+
+          cleanup_ios_diagnostics() {
+            kill "$SIM_LOG_PID" "$WATCHDOG_PID" 2>/dev/null || true
+          }
+          trap cleanup_ios_diagnostics EXIT
+
+          set +e
+          flutter --verbose test integration_test/notifications_schedule_ios_test.dart --no-pub --coverage --coverage-path coverage/integration_ios.info --dart-define=SENTRY_DSN=https://test@dsn.example.local/0 -d "$DEVICE_ID" 2>&1 | tee ci-ios-diagnostics/flutter-test.log
+          TEST_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          {
+            echo "=== flutter test exit ==="
+            echo "$TEST_EXIT"
+            echo
+            echo "=== date ==="
+            date -u
+            echo
+            echo "=== process snapshot ==="
+            ps -axo pid,ppid,etime,command | grep -E 'flutter|dart|xcodebuild|simctl|Runner|ios-deploy' | grep -v grep || true
+            echo
+            echo "=== simulator state ==="
+            xcrun simctl list "$DEVICE_ID"
+          } > ci-ios-diagnostics/post-test.txt 2>&1 || true
+          xcrun simctl io "$DEVICE_ID" screenshot ci-ios-diagnostics/post-test-screenshot.png > ci-ios-diagnostics/post-test-screenshot.txt 2>&1 || true
+          mkdir -p ci-ios-diagnostics/DiagnosticReports
+          find ~/Library/Logs/DiagnosticReports -type f -mtime -1 -exec cp {} ci-ios-diagnostics/DiagnosticReports/ \; 2>/dev/null || true
+
+          exit "$TEST_EXIT"
+
+      - name: Upload iOS integration diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-integration-diagnostics
+          path: ci-ios-diagnostics
+          if-no-files-found: warn
 
       - name: Upload iOS Podfile lockfile
         if: always()

--- a/docs/adr/ADR-006-reduce-ios-integration-test-runtime.md
+++ b/docs/adr/ADR-006-reduce-ios-integration-test-runtime.md
@@ -110,6 +110,17 @@ Effective with this ADR, `integration-test-ios` is **non-blocking telemetry**:
    upload on `if: always()` so PR reviewers retain the iOS coverage trace and
    the generated `Podfile.lock` needed for the deferred commit follow-up.
 
+Telemetry is still explicitly time-bounded. The job has a 60-minute ceiling,
+the simulator boot wait has a 10-minute ceiling, and the `flutter test` step
+has a 45-minute ceiling. `continue-on-error: true` only changes the result after
+a command exits or is timed out; it does not by itself interrupt a hung process.
+The iOS test step also runs Flutter in verbose mode, streams filtered simulator
+logs into `ci-ios-diagnostics/simulator.log`, starts a 40-minute watchdog that
+captures process/simulator state before the 45-minute step ceiling, and uploads
+`ios-integration-diagnostics` on `if: always()`. The iOS-only integration test
+emits `IOS_TEST_MARK` lifecycle markers so logs can distinguish "Dart test
+never started" from "test setup or teardown started and then hung".
+
 This mirrors the `unit-test-web-telemetry` treatment in the same workflow and
 applies the "revisit the quality gate shape" fallback proactively, rather than
 waiting for the runtime optimization to prove insufficient. Reasons:

--- a/integration_test/notifications_schedule_ios_test.dart
+++ b/integration_test/notifications_schedule_ios_test.dart
@@ -129,7 +129,9 @@ class _NoopPersistentMemoryService implements PersistentMemoryService {
 }
 
 void main() {
+  debugPrint('IOS_TEST_MARK: notifications_schedule_ios_test main entered');
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  debugPrint('IOS_TEST_MARK: integration binding initialized');
 
   const localNotifChannel = MethodChannel(
     'dexterous.com/flutter/local_notifications',
@@ -142,6 +144,7 @@ void main() {
   late String timezoneId;
 
   setUp(() async {
+    debugPrint('IOS_TEST_MARK: setUp start');
     await GetIt.instance.reset();
     GetIt.instance.registerSingleton<IncidentLoggerService>(_RecordingLogger());
 
@@ -191,14 +194,17 @@ void main() {
         }
       })
       ..setMockMethodCallHandler(toastChannel, (call) async => true);
+    debugPrint('IOS_TEST_MARK: setUp complete');
   });
 
   tearDown(() async {
+    debugPrint('IOS_TEST_MARK: tearDown start');
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       ..setMockMethodCallHandler(timezoneChannel, null)
       ..setMockMethodCallHandler(localNotifChannel, null)
       ..setMockMethodCallHandler(toastChannel, null);
     await GetIt.instance.reset();
+    debugPrint('IOS_TEST_MARK: tearDown complete');
   });
 
   group('supportsReminderSettings on real iOS binding', () {


### PR DESCRIPTION
# User description
## Summary
- bound the telemetry-only `integration-test-ios` job and iOS test step so stuck runs no longer consume the 360-minute default timeout
- run the iOS Flutter test in verbose mode while collecting filtered simulator logs, process snapshots, screenshots, and recent crash reports into `ios-integration-diagnostics`
- add `IOS_TEST_MARK` lifecycle markers to the iOS-only integration test so CI logs can distinguish runner/launch hangs from Dart test setup/teardown hangs

## Verification
- `dart format --set-exit-if-changed integration_test/notifications_schedule_ios_test.dart`
- Ruby workflow parse and assertions for iOS timeout/diagnostic keys
- `git diff --check` (only Git LF/CRLF warnings)
- `flutter analyze integration_test/notifications_schedule_ios_test.dart`

## Notes
The actual iOS runner behavior still has to be observed in GitHub Actions; this PR adds the diagnostics needed to identify the hang boundary on the next macOS run.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Bound the GitHub Actions telemetry job and iOS test step with strict timeouts while streaming verbose simulator logs, watchdog snapshots, and diagnostics into the <code>ios-integration-diagnostics</code> artifact so hung runs produce actionable data. Add <code>IOS_TEST_MARK</code> lifecycle markers inside the integration test binding so CI logs can distinguish runner launch hangs from Dart setup or teardown issues.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/278?tool=ast&topic=Telemetry+diagnostics>Telemetry diagnostics</a>
        </td><td>Instrument the GitHub Actions <code>integration-test-ios</code> workflow with strict job/step timeouts, verbose <code>flutter test</code> execution, filtered simulator logging, watchdog snapshots, and artifact uploads so telemetry-only runs expose diagnostics before they monopolize macOS runners.<details><summary>Modified files (2)</summary><ul><li>.github/workflows/main.yml</li>
<li>docs/adr/ADR-006-reduce-ios-integration-test-runtime.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>ci: instrument iOS int...</td><td>May 28, 2026</td></tr>
<tr><td>dekel@tovli.co.il</td><td>Merge branch 'main' in...</td><td>May 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/278?tool=ast&topic=Lifecycle+markers>Lifecycle markers</a>
        </td><td>Add <code>IOS_TEST_MARK</code> lifecycle markers around binding initialization, <code>setUp</code>, and <code>tearDown</code> so integration-test logs clearly surface whether hangs occur before or during Dart-level steps.<details><summary>Modified files (1)</summary><ul><li>integration_test/notifications_schedule_ios_test.dart</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>ci: instrument iOS int...</td><td>May 28, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/278?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>