### PR TITLE
UX Phase E: shared async loading/error contract (ADR-005)

### DIFF
--- a/docs/adr/ADR-005-resolve-ux-gaps.md
+++ b/docs/adr/ADR-005-resolve-ux-gaps.md
@@ -1,6 +1,6 @@
 # ADR-005: Resolve UX Gaps Identified in UX_GAPS Audit
 
-- **Status**: in-progress (Phases A, B, C, D shipped; E pending)
+- **Status**: accepted (Phases A, B, C, D, E shipped)
 - **Date**: 2026-05-24
 - **Deciders**: <leave blank for author to fill>
 - **Tags**: ux, accessibility, rtl, theming, crisis-safety, mental-health
@@ -35,6 +35,16 @@ Adopt the five-phase remediation order proposed in `UX_GAPS.md` §4, with each p
 
    *Shipped 2026-05-28.* `lib/util/theme/app_theme.dart` introduces an `AppColors` semantic token layer (`primary`, `secondary`, `surface`, `onSurface`, `error`, `onError`, `success`, plus non-`ColorScheme` `neutralLight`/`neutralDark`/`pdfTint`) and `buildLightTheme()` / `buildDarkThemeStub()`. `lib/main.dart` wires both onto `MaterialApp` (the unstyled `MaterialApp` flagged at `lib/main.dart:410-428`). The nine palette variables in `lib/util/styles.dart:5-13` are now `const` forwarders to `AppColors` tokens, preserving every call site. `myButtonStyle3` no longer takes raw `Colors.red`; it reads `AppColors.error` (same hex as Material red 500, so visually a no-op). Regression suite: `test/util/theme/app_theme_test.dart`. Material 3 flip is deferred — Material 2 is pinned (`useMaterial3: false`) because the brand button styles target M2 token names.
 5. **Phase E — Loading / error contract (S2).** Introduce one shared async widget (loading / error-with-retry / empty / data) and route every `FutureBuilder` through it. Remove the unconditional "finished" toast in `personalPlanWidget.dart:127`.
+
+   *Shipped 2026-05-29.* `lib/util/async/async_state_view.dart` introduces the shared contract the audit asked for (`UX_GAPS.md §1.5, §3.10`):
+   - `AsyncStateView<T>` wraps `FutureBuilder<T>` and routes the four states through one place — **loading** (`AsyncLoadingIndicator`), **error-with-retry** (`AsyncErrorRetry`, the previously-missing branch), **empty** (optional `emptyBuilder`), and **data** (`onData`). A future that rejects *or* resolves to `null` for a non-nullable `T` lands in the error state instead of silently rendering nothing.
+   - `AsyncLoadingIndicator` is a `Semantics`-labelled centred spinner (closing the "spinner has no screen-reader label" gap). It reads `AppLocalizations.asyncLoadingLabel`, falling back to a literal when no delegate is in scope.
+   - `AsyncErrorRetry` shows a localized message plus a retry button; colours read from `AppColors` (Phase D) and font sizes use `.sp` (Phase B).
+   - The only production `FutureBuilder` — the image grid in `lib/pages/FeelGood/feelGood.dart` — now routes through `AsyncStateView`; its loader is screen-reader announced and a failed load surfaces a retry instead of an empty grid. The bare boot spinners in `lib/main.dart` and `lib/pages/SignIn_Pages/introduction.dart` now carry the shared loading label.
+   - **Service fix (required for the above to be real):** `ImagePickerServiceImpl.loadImagePaths` previously caught *every* exception, logged it, and resolved normally — so the Feel Good future never rejected and the error-with-retry branch was dead code. It now distinguishes the two cases the audit implies: a **missing manifest** (first run / nothing saved) returns empty so the grid shows its add affordance, while a manifest that **exists but cannot be read** (corruption, permission, decode failure) is logged *and rethrown* so `AsyncStateView` actually reaches its error branch. `deleteImages` (used by the Settings reset flow in `UserSettings.dart`) was wrapped to stay best-effort so the rethrow does not abort a reset. Covered by `test/pages/FeelGood/feel_good_async_error_test.dart`, which drives the real `FeelGood` widget with a throwing picker and asserts the retry appears and then recovers.
+   - Three non-gendered strings (`asyncLoadingLabel`, `asyncErrorMessage`, `asyncRetryButton`) were added to `app_en/he/ar.arb` and regenerated. Non-gendered is deliberate so the shared widget needs no gender plumbing.
+   - The "finished downloading" toast in `personalPlanWidget.dart` was already made conditional in an earlier phase (it now shows `downloadFailed` when `fileService.download` returns `null`), so no further change was needed there.
+   - Regression suite: `test/util/async/async_state_view_test.dart` (real-widget tests across all four states + the no-localizations fallback).
 
 Each phase ships behind its own PR with a regression test where feasible. Phase A is the only phase blocked from being deferred — the others may be reordered post-A based on capacity.
 

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -395,5 +395,8 @@
   },
   "editEntryTooltip": "تعديل الإدخال",
   "deleteEntryTooltip": "حذف الإدخال",
-  "sosTooltip": "SOS — جهات اتصال الطوارئ"
+  "sosTooltip": "SOS — جهات اتصال الطوارئ",
+  "asyncLoadingLabel": "جارٍ التحميل",
+  "asyncErrorMessage": "حدث خطأ ما",
+  "asyncRetryButton": "إعادة المحاولة"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1647,5 +1647,17 @@
   "sosTooltip": "SOS — emergency contacts",
   "@sosTooltip": {
     "description": "Tooltip / TalkBack label for the floating SOS button"
+  },
+  "asyncLoadingLabel": "Loading",
+  "@asyncLoadingLabel": {
+    "description": "Phase E (ADR-005 §Decision step 5): Semantics/TalkBack label announced while a shared async view is in its loading state. Gender-neutral on purpose so the shared widget needs no gender plumbing."
+  },
+  "asyncErrorMessage": "Something went wrong.",
+  "@asyncErrorMessage": {
+    "description": "Phase E (ADR-005 §Decision step 5): generic message shown in the shared async view's error state, paired with a retry action."
+  },
+  "asyncRetryButton": "Try again",
+  "@asyncRetryButton": {
+    "description": "Phase E (ADR-005 §Decision step 5): label for the retry button in the shared async view's error state."
   }
 }

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -418,5 +418,8 @@
   },
   "editEntryTooltip": "עריכת רשומה",
   "deleteEntryTooltip": "מחיקת רשומה",
-  "sosTooltip": "SOS – אנשי קשר בשעת חירום"
+  "sosTooltip": "SOS – אנשי קשר בשעת חירום",
+  "asyncLoadingLabel": "טוען",
+  "asyncErrorMessage": "משהו השתבש",
+  "asyncRetryButton": "ניסיון חוזר"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2157,6 +2157,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'SOS — emergency contacts'**
   String get sosTooltip;
+
+  /// Phase E (ADR-005 §Decision step 5): Semantics/TalkBack label announced while a shared async view is in its loading state. Gender-neutral on purpose so the shared widget needs no gender plumbing.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading'**
+  String get asyncLoadingLabel;
+
+  /// Phase E (ADR-005 §Decision step 5): generic message shown in the shared async view's error state, paired with a retry action.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong.'**
+  String get asyncErrorMessage;
+
+  /// Phase E (ADR-005 §Decision step 5): label for the retry button in the shared async view's error state.
+  ///
+  /// In en, this message translates to:
+  /// **'Try again'**
+  String get asyncRetryButton;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3085,4 +3085,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get sosTooltip => 'SOS — جهات اتصال الطوارئ';
+
+  @override
+  String get asyncLoadingLabel => 'جارٍ التحميل';
+
+  @override
+  String get asyncErrorMessage => 'حدث خطأ ما';
+
+  @override
+  String get asyncRetryButton => 'إعادة المحاولة';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3113,4 +3113,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sosTooltip => 'SOS — emergency contacts';
+
+  @override
+  String get asyncLoadingLabel => 'Loading';
+
+  @override
+  String get asyncErrorMessage => 'Something went wrong.';
+
+  @override
+  String get asyncRetryButton => 'Try again';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3076,4 +3076,13 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get sosTooltip => 'SOS – אנשי קשר בשעת חירום';
+
+  @override
+  String get asyncLoadingLabel => 'טוען';
+
+  @override
+  String get asyncErrorMessage => 'משהו השתבש';
+
+  @override
+  String get asyncRetryButton => 'ניסיון חוזר';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:mazilon/AnalyticsService.dart';
 import 'package:mazilon/pages/notifications/notification_service.dart';
 import 'package:mazilon/pages/notifications/reminder_debug_recorder.dart';
 import 'package:mazilon/util/logger_service.dart';
+import 'package:mazilon/util/async/async_state_view.dart';
 import 'package:mazilon/util/persistent_memory_service.dart';
 import 'package:mazilon/util/theme/app_theme.dart';
 import 'package:provider/provider.dart';
@@ -450,8 +451,11 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         debugShowCheckedModeBanner: false,
         theme: buildLightTheme(),
         darkTheme: buildDarkThemeStub(),
+        // Phase E (ADR-005 §Decision step 5): this boot spinner renders
+        // before the localization delegates are wired, so it passes an
+        // explicit English label rather than reading AppLocalizations.
         home: const Scaffold(
-          body: Center(child: CircularProgressIndicator()),
+          body: AsyncLoadingIndicator(semanticLabel: 'Loading'),
         ),
       );
     }

--- a/lib/pages/FeelGood/feelGood.dart
+++ b/lib/pages/FeelGood/feelGood.dart
@@ -8,6 +8,7 @@ import 'package:mazilon/pages/FeelGood/image_display_item.dart';
 import 'package:mazilon/pages/FeelGood/image_picker_service_impl.dart';
 import 'package:mazilon/util/LP_extended_state.dart';
 import 'package:mazilon/util/appInformation.dart';
+import 'package:mazilon/util/async/async_state_view.dart';
 import 'package:mazilon/util/styles.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mazilon/util/userInformation.dart';
@@ -24,7 +25,7 @@ class FeelGood extends StatefulWidget {
 class _FeelGoodPageState extends LPExtendedState<FeelGood> {
   late ImagePickerService pickerService;
   List<String> imagePaths = [];
-  late Future<void> _loadImagesFuture;
+  late Future<List<String>> _loadImagesFuture;
   //final picker = ImagePicker();
   AnalyticsService mixPanelService = GetIt.instance<AnalyticsService>();
   @override
@@ -35,9 +36,21 @@ class _FeelGoodPageState extends LPExtendedState<FeelGood> {
     _loadImagesFuture = _loadImagePaths();
   }
 
-  Future<void> _loadImagePaths() async {
+  // Phase E (ADR-005 §Decision step 5): returns the loaded paths so the
+  // shared [AsyncStateView] can drive loading/error/data states. Clears
+  // first so a retry does not append duplicates onto a partial load.
+  Future<List<String>> _loadImagePaths() async {
+    imagePaths.clear();
     await pickerService.loadImagePaths(imagePaths);
-    setState(() {});
+    return imagePaths;
+  }
+
+  // Phase E: retry hook for the shared error state — re-arms the future so
+  // the FutureBuilder re-runs the load.
+  void _retryLoadImages() {
+    setState(() {
+      _loadImagesFuture = _loadImagePaths();
+    });
   }
 
   @override
@@ -110,16 +123,19 @@ class _FeelGoodPageState extends LPExtendedState<FeelGood> {
                   padding: const EdgeInsets.symmetric(horizontal: 8.0),
                   child: Scrollbar(
                     //images uploaded from phone grid view:
-                    child: FutureBuilder<void>(
+                    // Phase E (ADR-005 §Decision step 5): the bare
+                    // FutureBuilder here showed a spinner only while waiting
+                    // and rendered an empty grid on failure with no recovery
+                    // (UX_GAPS.md §3.10). Routed through the shared
+                    // AsyncStateView so loading is screen-reader announced and
+                    // a failed load surfaces a retry affordance.
+                    child: AsyncStateView<List<String>>(
                       future: _loadImagesFuture,
-                      builder: (context, snapshot) {
-                        if (snapshot.connectionState ==
-                            ConnectionState.waiting) {
-                          return const Center(
-                            child: CircularProgressIndicator(),
-                          );
-                        }
-
+                      onRetry: _retryLoadImages,
+                      // The data builder reads the live `imagePaths` field
+                      // (mutated by add/delete) rather than the resolved
+                      // snapshot, so the grid stays in sync after edits.
+                      onData: (context, _) {
                         return GridView.builder(
                           shrinkWrap:
                               true, // Ensures GridView works inside SingleChildScrollView

--- a/lib/pages/FeelGood/image_picker_service_impl.dart
+++ b/lib/pages/FeelGood/image_picker_service_impl.dart
@@ -30,7 +30,15 @@ class ImagePickerServiceImpl implements ImagePickerService {
   @override
   Future<void> deleteImages() async {
     List<String> tempPath = [];
-    await loadImagePaths(tempPath);
+    try {
+      await loadImagePaths(tempPath);
+    } catch (_) {
+      // Best-effort cleanup during the Settings reset flow. loadImagePaths
+      // now rethrows genuine read failures (and has already logged them); if
+      // the manifest cannot be read we cannot enumerate files to delete, so
+      // skip rather than abort the surrounding reset.
+      return;
+    }
 
     while (tempPath.isNotEmpty) {
       File(tempPath[0]).deleteSync();
@@ -84,6 +92,14 @@ class ImagePickerServiceImpl implements ImagePickerService {
   Future<void> loadImagePaths(List<String> imagePaths) async {
     try {
       final file = await getImagePathFile();
+      // First run / nothing saved yet is the EMPTY state, not an error: the
+      // manifest file simply does not exist. Return normally so the Feel Good
+      // grid renders its add affordance and AsyncStateView stays out of its
+      // error branch.
+      if (!await file.exists()) {
+        return;
+      }
+
       String contents = await file.readAsString();
 
       imagePaths.addAll(
@@ -95,9 +111,14 @@ class ImagePickerServiceImpl implements ImagePickerService {
         error,
         stackTrace: stackTrace,
       );
-      imagePaths = [];
+      // A manifest that exists but cannot be read (corruption, permission,
+      // decode failure) is a genuine failure. Phase E (ADR-005 §Decision
+      // step 5): rethrow so the caller's error UI surfaces it with a retry,
+      // instead of swallowing it and rendering an empty grid (UX_GAPS.md
+      // §3.10). The previous `imagePaths = []` reassigned the local parameter
+      // and was a no-op.
+      rethrow;
     }
-    // If encountering an error, return an empty list
   }
 
   Future<File> getImagePathFile() async {

--- a/lib/pages/SignIn_Pages/introduction.dart
+++ b/lib/pages/SignIn_Pages/introduction.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mazilon/util/LP_extended_state.dart';
 
+import 'package:mazilon/util/async/async_state_view.dart';
 import 'package:mazilon/util/styles.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
@@ -44,15 +45,13 @@ class _IntroductionState extends LPExtendedState<Introduction> {
             // Displaying a large circular progress indicator (spinner).
             // Phase E (ADR-005 §Decision step 5): the spinner carried no
             // screen-reader label (UX_GAPS.md §1.5). Announce it via the
-            // shared async loading label so TalkBack/VoiceOver users know the
-            // restart is in progress.
-            Semantics(
-              label: appLocale.asyncLoadingLabel,
-              liveRegion: true,
-              child: const SizedBox(
-                height: 300,
-                width: 300,
-                child: CircularProgressIndicator(),
+            // shared async loading indicator so TalkBack/VoiceOver users know
+            // the restart is in progress.
+            SizedBox(
+              height: 300,
+              width: 300,
+              child: AsyncLoadingIndicator(
+                semanticLabel: appLocale.asyncLoadingLabel,
               ),
             ),
           ],

--- a/lib/pages/SignIn_Pages/introduction.dart
+++ b/lib/pages/SignIn_Pages/introduction.dart
@@ -41,11 +41,19 @@ class _IntroductionState extends LPExtendedState<Introduction> {
                 null,
                 100),
             const SizedBox(height: 20.0),
-            // Displaying a large circular progress indicator (spinner)
-            const SizedBox(
-              height: 300,
-              width: 300,
-              child: CircularProgressIndicator(),
+            // Displaying a large circular progress indicator (spinner).
+            // Phase E (ADR-005 §Decision step 5): the spinner carried no
+            // screen-reader label (UX_GAPS.md §1.5). Announce it via the
+            // shared async loading label so TalkBack/VoiceOver users know the
+            // restart is in progress.
+            Semantics(
+              label: appLocale.asyncLoadingLabel,
+              liveRegion: true,
+              child: const SizedBox(
+                height: 300,
+                width: 300,
+                child: CircularProgressIndicator(),
+              ),
             ),
           ],
         ),

--- a/lib/util/async/async_state_view.dart
+++ b/lib/util/async/async_state_view.dart
@@ -1,0 +1,197 @@
+// Phase E (ADR-005 §Decision step 5) — shared async / loading-error contract.
+//
+// Before Phase E the app had no shared loading/error affordance. Async
+// flows each rolled their own `FutureBuilder` that showed a bare
+// `CircularProgressIndicator` only for `ConnectionState.waiting` and
+// silently rendered nothing on error (see `docs/UX_GAPS.md §1.5, §3.10`).
+// The bare spinners also carried no `Semantics` label (§1.5,
+// `introduction.dart`).
+//
+// This file introduces the single async widget the audit asked for:
+//   * [AsyncLoadingIndicator] — a Semantics-labelled centred spinner that
+//     the bare loaders (`main.dart`, `introduction.dart`) can also reuse.
+//   * [AsyncErrorRetry] — the error state, with a visible message and a
+//     retry action (the missing "error-with-retry" branch).
+//   * [AsyncStateView] — a `FutureBuilder` wrapper that routes every async
+//     state through one place: loading → error-with-retry → empty → data.
+//
+// House-style discipline carried over from earlier phases:
+//   * Phase B: every spinner is wrapped in `Semantics(label:)`; font sizes
+//     use `.sp` so they honour the user's system text-scale.
+//   * Phase C: layout leans on `Directionality` (inherited from the
+//     `MaterialApp` locale) rather than branching on `isRtl`.
+//   * Phase D: colours read from `AppColors` / `Theme.of(context)` tokens
+//     rather than raw `Colors.*`.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
+import 'package:mazilon/util/styles.dart';
+import 'package:mazilon/util/theme/app_theme.dart';
+
+/// Builds the data UI once the future resolves with a value.
+typedef AsyncDataBuilder<T> = Widget Function(BuildContext context, T data);
+
+/// Returns `true` when resolved [data] should render the empty state instead
+/// of the data state (e.g. an empty list).
+typedef AsyncEmptyPredicate<T> = bool Function(T data);
+
+/// A centred [CircularProgressIndicator] that announces itself to screen
+/// readers.
+///
+/// [semanticLabel] is optional: when omitted it reads
+/// `AppLocalizations.asyncLoadingLabel`, and if no localizations are in scope
+/// (e.g. the very first `MaterialApp` in `main.dart`, built before the
+/// delegates are wired) it falls back to a plain English label so the spinner
+/// is never silent to TalkBack/VoiceOver.
+class AsyncLoadingIndicator extends StatelessWidget {
+  final String? semanticLabel;
+
+  const AsyncLoadingIndicator({super.key, this.semanticLabel});
+
+  @override
+  Widget build(BuildContext context) {
+    final label = semanticLabel ??
+        AppLocalizations.of(context)?.asyncLoadingLabel ??
+        'Loading';
+    return Center(
+      child: Semantics(
+        label: label,
+        liveRegion: true,
+        child: const CircularProgressIndicator(),
+      ),
+    );
+  }
+}
+
+/// The error state for an async flow: an error glyph, a human message, and a
+/// retry button.
+///
+/// This is the "error-with-retry" branch the audit found missing. When
+/// [onRetry] is null the button is hidden (some flows have nothing to retry),
+/// but the message is still shown so the failure is never silent.
+class AsyncErrorRetry extends StatelessWidget {
+  final VoidCallback? onRetry;
+  final String? message;
+  final String? retryLabel;
+
+  const AsyncErrorRetry({
+    super.key,
+    this.onRetry,
+    this.message,
+    this.retryLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final locale = AppLocalizations.of(context);
+    final text = message ?? locale?.asyncErrorMessage ?? 'Something went wrong.';
+    final retryText = retryLabel ?? locale?.asyncRetryButton ?? 'Try again';
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              // Phase D: destructive/error semantics read from the token layer.
+              color: AppColors.error,
+              size: 40.sp,
+              semanticLabel: text,
+            ),
+            SizedBox(height: 12.h),
+            myAutoSizedText(
+              text,
+              TextStyle(fontSize: 16.sp),
+              TextAlign.center,
+              20,
+            ),
+            if (onRetry != null) ...[
+              SizedBox(height: 16.h),
+              Semantics(
+                button: true,
+                child: TextButton(
+                  onPressed: onRetry,
+                  style: myButtonStyle,
+                  child: myAutoSizedText(
+                    retryText,
+                    myTextStyle,
+                    TextAlign.center,
+                    20,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Routes a [future] through the four async states the audit asked for:
+/// loading → error-with-retry → empty → data.
+///
+/// * **loading** while the future is pending — [AsyncLoadingIndicator].
+/// * **error-with-retry** if the future rejects, or completes with `null` for
+///   a non-nullable [T] — [AsyncErrorRetry] wired to [onRetry].
+/// * **empty** when [isEmpty] returns true for the resolved data —
+///   [emptyBuilder] if provided, otherwise the data builder is used.
+/// * **data** otherwise — [onData].
+///
+/// Callers own the retry wiring: typically `onRetry` calls `setState` to
+/// re-assign the future field so the builder re-runs.
+class AsyncStateView<T> extends StatelessWidget {
+  final Future<T> future;
+  final AsyncDataBuilder<T> onData;
+  final VoidCallback? onRetry;
+  final AsyncEmptyPredicate<T>? isEmpty;
+  final WidgetBuilder? emptyBuilder;
+  final String? loadingLabel;
+  final String? errorMessage;
+  final String? retryLabel;
+
+  const AsyncStateView({
+    super.key,
+    required this.future,
+    required this.onData,
+    this.onRetry,
+    this.isEmpty,
+    this.emptyBuilder,
+    this.loadingLabel,
+    this.errorMessage,
+    this.retryLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<T>(
+      future: future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return AsyncLoadingIndicator(semanticLabel: loadingLabel);
+        }
+
+        // Treat both an outright rejection and a null result for a
+        // non-nullable T as the error state — the previous code rendered
+        // an empty grid in exactly these cases (`UX_GAPS.md §3.10`).
+        final resolvedToNull = snapshot.data == null && null is! T;
+        if (snapshot.hasError || resolvedToNull) {
+          return AsyncErrorRetry(
+            onRetry: onRetry,
+            message: errorMessage,
+            retryLabel: retryLabel,
+          );
+        }
+
+        final data = snapshot.data as T;
+        if (isEmpty != null && isEmpty!(data)) {
+          return emptyBuilder?.call(context) ?? onData(context, data);
+        }
+        return onData(context, data);
+      },
+    );
+  }
+}

--- a/test/FeelGood/image_picker_service_impl_test.dart
+++ b/test/FeelGood/image_picker_service_impl_test.dart
@@ -9,8 +9,10 @@
 //   - `deleteImage(index, paths)` deletes the file + removes from the list
 //   - `loadImagePaths` reads back what `saveImagePaths` wrote (using a
 //     `path_provider` mock that returns a real OS temp dir)
-//   - `loadImagePaths` error path captures via the registered
-//     IncidentLoggerService when the persisted file is absent
+//   - `loadImagePaths` treats a missing manifest as the empty first-run
+//     state: returns normally, leaves the list empty, logs nothing
+//     (genuine read failures are covered by the widget test in
+//     test/pages/FeelGood/feel_good_async_error_test.dart)
 //
 // The actual ImagePicker.pickImage path requires native code so we don't
 // drive it.
@@ -111,12 +113,19 @@ void main() {
     expect(loaded, equals(paths));
   });
 
-  test('loadImagePaths on missing file captures error via logger', () async {
+  test('loadImagePaths on missing file returns empty without logging an error',
+      () async {
     final svc = ImagePickerServiceImpl();
     final loaded = <String>[];
-    // No file written yet; readAsString will throw.
+    // No file written yet. Phase E (ADR-005 §Decision step 5): a missing
+    // manifest is the empty first-run state, NOT an error — loadImagePaths
+    // must return normally, leave the list empty, and log nothing, so
+    // AsyncStateView stays out of its error branch and the Feel Good grid
+    // shows its add affordance. Genuine read failures (manifest present but
+    // unreadable) are logged + rethrown and covered by the widget test.
     await svc.loadImagePaths(loaded);
-    expect(logger.captured, isNotEmpty);
+    expect(loaded, isEmpty);
+    expect(logger.captured, isEmpty);
   });
 
   test('deleteImage removes entry at index and the file on disk', () async {

--- a/test/pages/FeelGood/feel_good_async_error_test.dart
+++ b/test/pages/FeelGood/feel_good_async_error_test.dart
@@ -1,0 +1,112 @@
+// Phase E regression suite (ADR-005 §Decision step 5) — production path.
+//
+// The shared AsyncStateView only earns its keep if the REAL Feel Good load
+// path can actually reach the error-with-retry branch. Before the Phase E
+// service fix, ImagePickerServiceImpl.loadImagePaths swallowed every
+// exception, so the future always resolved and the error branch was dead
+// code (the empty-grid-on-failure bug, UX_GAPS.md §3.10).
+//
+// This test drives the real FeelGood widget with an ImagePickerService whose
+// loadImagePaths rejects, and asserts the error UI appears — then that a
+// retry recovers once the service stops failing. No stubbed widgets (see the
+// team's real-widget test-pattern note).
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mazilon/pages/FeelGood/feelGood.dart';
+import 'package:mazilon/pages/FeelGood/image_picker_service_impl.dart';
+
+import '../../helpers/widget_test_scaffold.dart';
+
+/// Picker whose [loadImagePaths] throws until [failLoad] is flipped to false,
+/// mirroring a manifest that exists but cannot be read.
+class _FlakyImagePickerService implements ImagePickerService {
+  // Starts failing; flipped to false in the recovery test to simulate the
+  // manifest becoming readable again.
+  bool failLoad = true;
+
+  @override
+  Future<void> loadImagePaths(List<String> imagePaths) async {
+    if (failLoad) {
+      throw const FileSystemException('cannot read manifest');
+    }
+    // Recovered: nothing saved yet -> empty list (grid shows add affordance).
+  }
+
+  @override
+  Future<XFile?> pickImage({required ImageSource source}) async => null;
+
+  @override
+  Future<File> saveImagePaths(List<String> imagePaths) async =>
+      File('${Directory.systemTemp.path}/flaky-image-paths.txt');
+
+  @override
+  Future<void> getImage(String source, List<String> imagePaths) async {}
+
+  @override
+  void deleteImage(int index, List<String> imagePaths) {}
+
+  @override
+  displayImage(String path, {BoxFit fit = BoxFit.none}) =>
+      Image.memory(Uint8List(0), fit: fit, errorBuilder: (_, _, _) {
+        return const SizedBox.shrink();
+      });
+
+  @override
+  Widget getOnlineImage(String url) => const SizedBox.shrink();
+
+  @override
+  Future<void> deleteImages() async {}
+}
+
+void main() {
+  late _FlakyImagePickerService flaky;
+
+  setUp(() {
+    registerTestServices();
+    // Swap the Noop picker for one that fails the load.
+    flaky = _FlakyImagePickerService();
+    final getIt = GetIt.instance;
+    getIt.unregister<ImagePickerService>();
+    getIt.registerSingleton<ImagePickerService>(flaky);
+  });
+
+  tearDown(() {
+    resetTestServices();
+  });
+
+  testWidgets('Feel Good surfaces a retry when the image load fails',
+      (tester) async {
+    await pumpWithProviders(tester, const FeelGood());
+    await tester.pumpAndSettle();
+
+    // Error contract is reached on the real production path.
+    expect(find.text('Something went wrong.'), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+    // The grid is NOT rendered behind the error (the old empty-grid bug).
+    expect(find.byType(GridView), findsNothing);
+  });
+
+  testWidgets('retry recovers once the load stops failing', (tester) async {
+    await pumpWithProviders(tester, const FeelGood());
+    await tester.pumpAndSettle();
+    expect(find.text('Try again'), findsOneWidget);
+
+    // Service recovers, user taps retry. The button sits inside the page's
+    // scroll view, so bring it into view before tapping.
+    flaky.failLoad = false;
+    await tester.ensureVisible(find.text('Try again'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
+
+    // Error UI is gone and the grid (with its add affordance) renders.
+    expect(find.text('Something went wrong.'), findsNothing);
+    expect(find.byType(GridView), findsOneWidget);
+  });
+}

--- a/test/util/async/async_state_view_test.dart
+++ b/test/util/async/async_state_view_test.dart
@@ -1,0 +1,171 @@
+// Phase E regression suite (ADR-005 §Decision step 5).
+//
+// Pins the shared async / loading-error contract introduced in
+// `lib/util/async/async_state_view.dart`. The audit (`docs/UX_GAPS.md §1.5,
+// §3.10`) flagged that async flows showed a bare spinner only while waiting,
+// rendered nothing on error, and carried no screen-reader label. These tests
+// exercise the REAL production widget (no stubs — see the team's test-pattern
+// note) across all four states: loading, error-with-retry, empty, data.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mazilon/util/async/async_state_view.dart';
+
+import '../../helpers/widget_test_scaffold.dart';
+
+void main() {
+  setUp(() {
+    registerTestServices();
+  });
+
+  tearDown(() {
+    resetTestServices();
+  });
+
+  group('AsyncStateView', () {
+    testWidgets('shows a screen-reader-labelled spinner while waiting',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      // A future that never completes keeps the view in the loading state.
+      final never = Completer<List<String>>();
+      addTearDown(() => never.complete(const []));
+
+      await pumpWithProviders(
+        tester,
+        AsyncStateView<List<String>>(
+          future: never.future,
+          onData: (_, _) => const Text('data'),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      // English loading label from app_en.arb.
+      expect(find.bySemanticsLabel('Loading'), findsOneWidget);
+      expect(find.text('data'), findsNothing);
+
+      // Dispose before the test body ends — the framework's
+      // handle-leak check runs ahead of addTearDown callbacks.
+      handle.dispose();
+    });
+
+    testWidgets('renders data when the future resolves', (tester) async {
+      await pumpWithProviders(
+        tester,
+        AsyncStateView<List<String>>(
+          future: Future.value(const ['a', 'b']),
+          onData: (_, data) => Text('items:${data.length}'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('items:2'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('shows error message and retry button when future rejects',
+        (tester) async {
+      var retried = 0;
+
+      // Complete with the error AFTER pump so FutureBuilder is already
+      // listening — an eagerly-created Future.error reads as "unhandled" to
+      // the test zone.
+      final completer = Completer<List<String>>();
+      await pumpWithProviders(
+        tester,
+        AsyncStateView<List<String>>(
+          future: completer.future,
+          onRetry: () => retried++,
+          onData: (_, _) => const Text('data'),
+        ),
+      );
+      completer.completeError(Exception('boom'));
+      await tester.pumpAndSettle();
+
+      // The data branch must NOT render on error (the old bug rendered an
+      // empty grid silently).
+      expect(find.text('data'), findsNothing);
+      // English error + retry strings from app_en.arb.
+      expect(find.text('Something went wrong.'), findsOneWidget);
+      expect(find.text('Try again'), findsOneWidget);
+
+      await tester.tap(find.text('Try again'));
+      await tester.pump();
+      expect(retried, 1);
+    });
+
+    testWidgets('hides retry button when no onRetry is provided',
+        (tester) async {
+      final completer = Completer<List<String>>();
+      await pumpWithProviders(
+        tester,
+        AsyncStateView<List<String>>(
+          future: completer.future,
+          onData: (_, _) => const Text('data'),
+        ),
+      );
+      completer.completeError(Exception('boom'));
+      await tester.pumpAndSettle();
+
+      // Message still shown (failure is never silent) but no retry control.
+      expect(find.text('Something went wrong.'), findsOneWidget);
+      expect(find.text('Try again'), findsNothing);
+    });
+
+    testWidgets('routes through emptyBuilder when isEmpty is true',
+        (tester) async {
+      await pumpWithProviders(
+        tester,
+        AsyncStateView<List<String>>(
+          future: Future.value(const <String>[]),
+          isEmpty: (data) => data.isEmpty,
+          emptyBuilder: (_) => const Text('nothing here'),
+          onData: (_, _) => const Text('data'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('nothing here'), findsOneWidget);
+      expect(find.text('data'), findsNothing);
+    });
+
+    testWidgets('falls back to data builder when empty but no emptyBuilder',
+        (tester) async {
+      await pumpWithProviders(
+        tester,
+        AsyncStateView<List<String>>(
+          future: Future.value(const <String>[]),
+          isEmpty: (data) => data.isEmpty,
+          onData: (_, data) => Text('data:${data.length}'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('data:0'), findsOneWidget);
+    });
+  });
+
+  group('AsyncLoadingIndicator', () {
+    testWidgets('uses an explicit label without any localizations in scope',
+        (tester) async {
+      final handle = tester.ensureSemantics();
+
+      // Deliberately NOT using pumpWithProviders: no AppLocalizations
+      // delegate, mirroring the boot spinner in main.dart.
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AsyncLoadingIndicator(semanticLabel: 'Booting'),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.bySemanticsLabel('Booting'), findsOneWidget);
+
+      handle.dispose();
+    });
+  });
+}


### PR DESCRIPTION
# User description
## Summary

UX **Phase E** of ADR-005 — the shared loading/error contract (S2, `UX_GAPS.md` §1.5, §3.10). Introduces one shared async widget and routes the app's async surfaces through it, so loading is screen-reader announced and failures surface a retry instead of silently rendering nothing.

This completes the ADR-005 phase plan (A–E all shipped).

## What's in here

**New shared widget — `lib/util/async/async_state_view.dart`**
- `AsyncStateView<T>` — `FutureBuilder` wrapper routing **loading → error-with-retry → empty → data**. A future that rejects, or resolves to `null` for a non-nullable `T`, lands in the error branch instead of an empty render.
- `AsyncLoadingIndicator` — `Semantics`-labelled spinner (closes the "spinner has no screen-reader label" gap); reads `asyncLoadingLabel`, falling back to a literal when no l10n delegate is in scope.
- `AsyncErrorRetry` — localized message + retry button; colours from `AppColors` (Phase D), font sizes in `.sp` (Phase B).

**Routed the async surfaces through it**
- `lib/pages/FeelGood/feelGood.dart` — the only production `FutureBuilder`; loader is now announced and a failed load shows a retry.
- `lib/main.dart` + `lib/pages/SignIn_Pages/introduction.dart` — bare boot spinners now carry the shared loading label.

**Service fix (made the error branch reachable on the real path)**
- `ImagePickerServiceImpl.loadImagePaths` previously caught *every* exception and resolved normally, so the Feel Good future never rejected and the error branch was dead code. It now distinguishes:
  - **missing manifest** (first run / nothing saved) → empty state, grid shows its add affordance;
  - **manifest present but unreadable** (corruption/permission/decode) → logged **and rethrown** so `AsyncStateView` reaches its error branch.
- `deleteImages` wrapped to stay best-effort so the Settings reset flow is unaffected by the rethrow.

**Localization** — added non-gendered `asyncLoadingLabel` / `asyncErrorMessage` / `asyncRetryButton` to `en/he/ar` and regenerated. Non-gendered on purpose so the shared widget needs no gender plumbing.

## Tests

- `test/util/async/async_state_view_test.dart` — all four states + the no-localizations label fallback (+7).
- `test/pages/FeelGood/feel_good_async_error_test.dart` — drives the **real** `FeelGood` widget with a throwing picker; asserts the retry appears and then recovers (+2).
- `test/FeelGood/image_picker_service_impl_test.dart` — updated to the new "missing manifest = empty, no log" contract.

All touched suites green (async + FeelGood widget/service + UserSettings reset = **34 passing**). `flutter analyze` clean on the new files.

## Notes / out of scope
- `personalPlanWidget` "finished downloading" toast was already made conditional in an earlier phase — no change needed (noted in the ADR).
- Wellness Tools captions/transcripts (§3.9), Material 3 flip, and a real dark palette remain deferred per the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce the shared <code>AsyncStateView</code> flow (with <code>AsyncLoadingIndicator</code>/<code>AsyncErrorRetry</code>) so async loading is announced, failure surfaces a retry, and localization plus regression tests cover the four-state contract. Update the image picker path handling and ADR status to reflect the post-Phase E behavior and acceptance of the ADR plan.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/280?tool=ast&topic=ADR+Phase+Status>ADR Phase Status</a>
        </td><td>Document that ADR-005 Phases A–E are now shipped and accepted so the UX audit remediation plan is complete.<details><summary>Modified files (1)</summary><ul><li>docs/adr/ADR-005-resolve-ux-gaps.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>UX Phase E: shared asy...</td><td>May 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/280?tool=ast&topic=Accessible+Async+UX>Accessible Async UX</a>
        </td><td>Introduce the shared <code>AsyncStateView</code>, <code>AsyncLoadingIndicator</code>, and <code>AsyncErrorRetry</code> widgets, wire them through the FeelGood grid plus the boot spinners, add localized labels via the regenerated AR/EN/HE bundles and <code>AppLocalizations</code> getters, and cover every state with widget/regression tests so loading is announced and retries appear instead of silent failures.<details><summary>Modified files (13)</summary><ul><li>lib/l10n/app_ar.arb</li>
<li>lib/l10n/app_en.arb</li>
<li>lib/l10n/app_he.arb</li>
<li>lib/l10n/app_localizations.dart</li>
<li>lib/l10n/app_localizations_ar.dart</li>
<li>lib/l10n/app_localizations_en.dart</li>
<li>lib/l10n/app_localizations_he.dart</li>
<li>lib/main.dart</li>
<li>lib/pages/FeelGood/feelGood.dart</li>
<li>lib/pages/SignIn_Pages/introduction.dart</li>
<li>lib/util/async/async_state_view.dart</li>
<li>test/pages/FeelGood/feel_good_async_error_test.dart</li>
<li>test/util/async/async_state_view_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>UX Phase E: shared asy...</td><td>May 29, 2026</td></tr>
<tr><td>dekel@tovli.co.il</td><td>Merge branch 'main' in...</td><td>May 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/280?tool=ast&topic=Image+Picker+Errors>Image Picker Errors</a>
        </td><td>Make <code>ImagePickerServiceImpl.loadImagePaths</code> only treat a missing manifest as an empty state while logging-and-rethrowing true read failures, keep <code>deleteImages</code> best-effort, and update its tests so the new error path can trigger the shared error-with-retry UI without breaking the reset flow.<details><summary>Modified files (2)</summary><ul><li>lib/pages/FeelGood/image_picker_service_impl.dart</li>
<li>test/FeelGood/image_picker_service_impl_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Dekel@tovli.co.il</td><td>UX Phase E: shared asy...</td><td>May 29, 2026</td></tr>
<tr><td>davida1996@campus.tech...</td><td>changed all prints to ...</td><td>July 23, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/280?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>