### PR TITLE
Fix issue 253 custom category follow-up

### DIFF
--- a/docs/manual-regression-test-guide.md
+++ b/docs/manual-regression-test-guide.md
@@ -1,0 +1,340 @@
+# Mazilon Manual Regression Test Guide
+
+Use this guide before merging UI, navigation, persistence, locale, notification, or Personal Plan changes. It is written for a tester using a local Flutter checkout and an Android emulator, with optional web checks.
+
+## 1. Test Setup
+
+### Devices
+
+- Primary manual device: Android emulator, preferably `emulator-5554` / Pixel 9a2.
+- Secondary checks when relevant: Chrome web and one narrow-screen Android viewport.
+- App package: `com.matzilon.mezilon`.
+
+### Baseline Commands
+
+Run these before a manual regression pass:
+
+```powershell
+flutter pub get
+adb devices
+flutter analyze
+flutter test
+```
+
+If the full suite is too slow for a quick smoke pass, run the focused high-risk checks:
+
+```powershell
+flutter test test/form/shareform_test.dart
+flutter test test/file_service_custom_categories_test.dart test/personal_plan_custom_categories_test.dart
+flutter test test/MenuTest/reminder_visibility_test.dart test/MenuTest/Wellness/wellnessTools_test.dart
+flutter test test/EmergencyPhones_test.dart test/emergency_whatsapp_test.dart
+```
+
+For the custom-category Android regression:
+
+```powershell
+flutter test integration_test/custom_categories_e2e_test.dart -d emulator-5554
+```
+
+### Reset App State
+
+Use a clean state when testing onboarding, disclaimer, first-run language, or saved-plan persistence:
+
+```powershell
+adb -s emulator-5554 shell pm clear com.matzilon.mezilon
+flutter run -d emulator-5554
+```
+
+Use an existing state when testing persistence across restart, editing, repeated additions, notifications, and saved user data.
+
+### Evidence Capture
+
+For visual evidence:
+
+```powershell
+New-Item -ItemType Directory -Force .\tmp
+adb -s emulator-5554 exec-out screencap -p > .\tmp\regression-screen.png
+```
+
+For UI-tree evidence when a tap seems wrong:
+
+```powershell
+New-Item -ItemType Directory -Force .\tmp
+adb -s emulator-5554 exec-out uiautomator dump /dev/tty > .\tmp\ui-tree.xml
+```
+
+For crash logs:
+
+```powershell
+New-Item -ItemType Directory -Force .\tmp
+adb -s emulator-5554 logcat -c
+adb -s emulator-5554 shell pidof -s com.matzilon.mezilon
+adb -s emulator-5554 logcat -d > .\tmp\logcat.txt
+```
+
+When testing Hebrew menu hit targets, use the UI tree or accessibility labels when possible rather than guessing from screenshots.
+
+## 2. Smoke Pass
+
+Run this after every branch that touches UI, navigation, localization, local persistence, PDF/share, phone/SOS, notifications, or the Personal Plan.
+
+| Area | Steps | Expected Result |
+|---|---|---|
+| Launch | Install or run the app on Android. | App opens without crash, blank screen, or stuck loader. |
+| Home | Confirm the main screen renders with bottom navigation and SOS button. | Home content is visible and no controls overlap. |
+| Bottom nav | Tap Home, My Plan, Feel Good, and Support Tools. | Each tab opens the correct page and selected state updates. |
+| SOS | Tap the center SOS floating button. | Emergency phone page opens. |
+| Main menu | Open the hamburger/menu button from Home. | Menu appears near the tapped control and is not clipped. |
+| Back handling | Press Android back from a secondary page. | App returns to Home or exits only from Home. |
+| Restart | Close and reopen the app. | Saved local state still loads and no first-run screen reappears incorrectly. |
+
+## 3. First-Run And Locale Regression
+
+Use a clean app state for this section.
+
+1. Launch the app.
+2. Verify the disclaimer and language selector appear when expected.
+3. Accept the disclaimer.
+4. Choose Hebrew, English, and Arabic in separate passes.
+5. Confirm RTL pages align correctly in Hebrew and Arabic.
+6. Confirm English pages are LTR.
+7. Restart the app.
+
+Expected:
+
+- The selected language persists after restart.
+- Hebrew and Arabic text is readable, aligned correctly, and not clipped.
+- Buttons and dropdowns remain tappable in both RTL and LTR.
+- No raw localization keys such as `sharePage...` or `finishedDownloading` appear.
+
+## 4. Personal Plan Flow
+
+This is a high-risk regression area because the app stores safety-plan data and exports it.
+
+1. Start from a clean state.
+2. Complete the onboarding and Personal Plan form with realistic input in Hebrew.
+3. Include at least one answer in each standard section.
+4. Add emergency contacts when prompted.
+5. Reach the final share/update page.
+6. Tap `סיימתי!`.
+7. Open My Plan from bottom navigation.
+8. Restart the app and open My Plan again.
+
+Expected:
+
+- The flow can be completed without being trapped on a page.
+- User-entered text remains in the original language.
+- My Plan shows the saved sections in the expected order.
+- Empty answers are not displayed as blank plan items.
+- Bottom navigation and SOS remain usable after completing the flow.
+
+## 5. Custom Categories Regression
+
+Run this whenever `lib/form/shareform.dart`, `file_service.dart`, My Plan, PDF/share, or localization changes.
+
+1. Reach the final Personal Plan share/update page.
+2. Tap `+ הוספת קטגוריה`.
+3. Tap the category title field.
+4. Confirm all dropdown suggestions are shown:
+   - `משפטים מחזקים שחשוב לי לזכור`
+   - `אירועים מהעבר לתזכורת`
+   - `דברים עלי שחשוב לי שנזכור`
+   - `אפשרות לכתוב משהו מקורי משלי`
+5. Choose a predefined title and enter a free-text description.
+6. Save the category.
+7. Tap `+ הוספת קטגוריה` again without leaving the page.
+8. Tap the title field again.
+9. Confirm the same dropdown suggestions appear again.
+10. Add a second category using a completely custom title.
+11. Edit the first saved category.
+12. Confirm the edit form is prefilled and the dropdown suggestions are still available from the title field.
+13. Save the edited category.
+14. Delete the second category.
+15. Restart the app and open My Plan.
+
+Expected:
+
+- Dropdown suggestions are available every time the user adds or edits a category.
+- Custom title and description text is not translated by the app.
+- Edited text replaces the old text and persists after restart.
+- Deleted categories disappear immediately and do not reappear after restart.
+- `סיימתי!` is below the custom-category area, not above it.
+- My Plan and PDF/share output include only the current saved custom categories.
+
+## 6. Emergency Phones And SOS
+
+Run on Android with a realistic country selection.
+
+1. Open SOS from the floating button.
+2. Verify emergency phone categories render.
+3. Tap a phone row.
+4. If a confirmation/dialog appears, verify the displayed number and action text.
+5. Add a manual contact through the phone form.
+6. Edit the contact name and number.
+7. Delete the contact.
+8. Restart the app.
+
+Expected:
+
+- Emergency categories and numbers match the selected country.
+- Phone links do not crash the app.
+- Manual contacts can be added, edited, deleted, and persist correctly.
+- Deletions do not return after restart.
+
+## 7. Main Menu, Settings, Contact, And Reminders
+
+Menu hit targets have regressed before, so verify each path separately.
+
+1. Open the main menu from Home.
+2. Tap About.
+3. Return Home and open the menu again.
+4. Tap Settings / `הגדרות`.
+5. Change name, age, gender, and language.
+6. Save or leave according to the current UI.
+7. Return Home and verify displayed language/user data.
+8. Open the menu again.
+9. Tap Reminders / `תזכורות` if shown on Android.
+10. Return Home and open the menu again.
+11. Tap Contact Us.
+12. Open the menu again and tap Share App.
+
+Expected:
+
+- About opens the About page.
+- Settings opens user settings, not reminders.
+- Reminders opens the reminder page, not settings.
+- Contact Us opens the support URL in the right language:
+  - Hebrew UI: Hebrew support site.
+  - English/Arabic UI: English support site.
+- Share App opens the platform share sheet without crashing.
+
+## 8. Notifications Regression
+
+Run on Android only. Reminder controls are intentionally hidden or disabled on unsupported platforms.
+
+1. Open Reminders from the main menu.
+2. Select a reminder time.
+3. Save or schedule the reminder.
+4. Leave the page and return.
+5. Cancel the reminder.
+6. Restart the app and return to Reminders.
+
+Expected:
+
+- Reminder page is reachable on Android.
+- Time picker displays the selected hour/minute correctly.
+- Scheduling does not crash or show plugin errors.
+- Cancel action clears the active reminder state.
+- Reminder controls do not appear on web/iOS/macOS if the platform gate says unsupported.
+
+## 9. Journal And Positive Traits
+
+1. Open the gratitude journal.
+2. Add a gratitude item.
+3. Edit the item.
+4. Delete the item.
+5. Restart the app.
+6. Open Positive Traits.
+7. Add a trait.
+8. Edit and delete it.
+9. Restart the app again.
+
+Expected:
+
+- Add/edit/delete works for both lists.
+- User-entered Hebrew and English text remains exactly as typed.
+- Empty states are readable.
+- Deleted items do not reappear.
+- The UI does not resize or overlap when text is long.
+
+## 10. Feel Good And Wellness Tools
+
+1. Open Feel Good from bottom navigation.
+2. Add an image if the feature is available on the target platform.
+3. Delete the image.
+4. Open Support Tools / Wellness Tools.
+5. Open a video item.
+6. Toggle full-screen video mode if available.
+7. Return to the main app.
+
+Expected:
+
+- Image picker permission handling does not crash the app.
+- Deleted images disappear.
+- Video list filters by the active locale.
+- Full-screen mode hides bottom navigation and SOS while active.
+- Exiting full-screen restores normal navigation.
+
+## 11. PDF, Download, And Share
+
+Run after creating a plan with standard sections, emergency phones, and custom categories.
+
+1. Open the final share/update page.
+2. Tap the share icon.
+3. Cancel the platform share sheet.
+4. Tap the download icon.
+5. Check for success/failure toast.
+6. Open the generated PDF if available.
+
+Expected:
+
+- Share and download actions do not crash.
+- PDF includes standard plan sections, phone section, and custom categories.
+- Hebrew/Arabic text direction is readable in exported content.
+- Empty sections are omitted or rendered according to existing behavior.
+
+## 12. Web Regression Pass
+
+Run this when touching localization, layout, file/share behavior, or browser-specific code:
+
+```powershell
+flutter run -d chrome
+```
+
+Check:
+
+- App launches in Chrome without console errors that break the UI.
+- Hebrew and Arabic pages use RTL layout.
+- Bottom navigation fits on narrow browser widths.
+- Contact Us opens a new tab.
+- Android-only reminder controls are hidden.
+- Phone links and share/download behavior degrade gracefully.
+
+## 13. Regression Triage Rules
+
+Use these rules before filing or fixing a regression:
+
+- Reproduce once from clean app state and once from existing saved state when persistence is involved.
+- For Hebrew menu issues, verify the exact tapped row: `תזכורות` and `הגדרות` are separate flows.
+- Capture a screenshot and, for hit-target bugs, a UI tree.
+- Record device, locale, branch, commit, and whether app data was cleared.
+- Do not infer Android behavior from Chrome or Chrome behavior from Android.
+- If a bug affects saved Personal Plan content, PDF export, emergency phones, disclaimer, or reminders, treat it as high priority.
+
+## 14. Suggested Release Checklist
+
+Before a release candidate, complete this minimum manual set:
+
+- Clean first-run flow in Hebrew.
+- Existing-state restart/persistence check.
+- Personal Plan completion and My Plan review.
+- Custom categories add, second add dropdown, edit, delete, restart.
+- SOS and emergency phone page.
+- Main menu settings/reminders/contact/share.
+- Reminder schedule/cancel on Android.
+- PDF share/download from a populated plan.
+- One English pass and one Arabic RTL pass.
+- One Chrome launch/layout pass if the release includes web.
+
+Record results as:
+
+```text
+Branch:
+Commit:
+Device:
+Locale:
+App data cleared: yes/no
+Checks passed:
+Issues found:
+Screenshots/logs:
+```

--- a/integration_test/custom_categories_e2e_test.dart
+++ b/integration_test/custom_categories_e2e_test.dart
@@ -140,6 +140,13 @@ void main() {
 
     await tester.tap(find.text('+ הוספת קטגוריה'));
     await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('custom-category-title-field')));
+    await tester.pumpAndSettle();
+    expect(find.text('משפטים מחזקים שחשוב לי לזכור'), findsOneWidget);
+    expect(find.text('אירועים מהעבר לתזכורת'), findsOneWidget);
+    expect(find.text('דברים עלי שחשוב לי שנזכור'), findsOneWidget);
+    expect(find.text('אפשרות לכתוב משהו מקורי משלי'), findsOneWidget);
+
     await tester.enterText(
       find.byKey(const Key('custom-category-title-field')),
       'Integration English title',

--- a/lib/form/shareform.dart
+++ b/lib/form/shareform.dart
@@ -40,12 +40,12 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
   final List<MapEntry<String, String>> _customCategories = [];
   bool _isAddingCustomCategory = false;
   bool _showCustomCategoryValidation = false;
+  int? _editingCustomCategoryIndex;
+  int _customCategoryFormGeneration = 0;
 
   void setHasFilled() async {
-    PersistentMemoryService service =
-        GetIt.instance<
-          PersistentMemoryService
-        >(); // Get the persistent memory service instance
+    PersistentMemoryService service = GetIt.instance<
+        PersistentMemoryService>(); // Get the persistent memory service instance
 
     await service.setItem("hasFilled", PersistentMemoryType.Bool, true);
   }
@@ -134,14 +134,54 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
     return getDirectionOfText(text) == 'rtl' ? TextAlign.right : TextAlign.left;
   }
 
+  void resetCustomCategoryForm() {
+    _customCategoryTitleController.clear();
+    _customCategoryDescriptionController.clear();
+    _customCategoryTitleFocusNode.unfocus();
+    _showCustomCategoryValidation = false;
+    _editingCustomCategoryIndex = null;
+    _customCategoryFormGeneration++;
+  }
+
   void startAddingCustomCategory() {
     setState(() {
+      resetCustomCategoryForm();
       _isAddingCustomCategory = true;
-      _showCustomCategoryValidation = false;
     });
   }
 
-  Future<void> addCustomCategory() async {
+  void editCustomCategory(int index) {
+    final category = _customCategories[index];
+    setState(() {
+      _customCategoryTitleController.text = category.key;
+      _customCategoryDescriptionController.text = category.value;
+      _showCustomCategoryValidation = false;
+      _editingCustomCategoryIndex = index;
+      _isAddingCustomCategory = true;
+      _customCategoryFormGeneration++;
+    });
+  }
+
+  Future<void> deleteCustomCategory(int index) async {
+    if (index < 0 || index >= _customCategories.length) {
+      return;
+    }
+
+    setState(() {
+      _customCategories.removeAt(index);
+      if (_editingCustomCategoryIndex == index) {
+        resetCustomCategoryForm();
+        _isAddingCustomCategory = false;
+      } else if (_editingCustomCategoryIndex != null &&
+          _editingCustomCategoryIndex! > index) {
+        _editingCustomCategoryIndex = _editingCustomCategoryIndex! - 1;
+      }
+    });
+
+    await saveCustomCategories();
+  }
+
+  Future<void> saveCustomCategory() async {
     final title = _customCategoryTitleController.text.trim();
     final description = _customCategoryDescriptionController.text.trim();
 
@@ -153,25 +193,56 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
     }
 
     setState(() {
-      _customCategories.add(MapEntry(title, description));
-      _customCategoryTitleController.clear();
-      _customCategoryDescriptionController.clear();
+      final editingIndex = _editingCustomCategoryIndex;
+      if (editingIndex != null &&
+          editingIndex >= 0 &&
+          editingIndex < _customCategories.length) {
+        _customCategories[editingIndex] = MapEntry(title, description);
+      } else {
+        _customCategories.add(MapEntry(title, description));
+      }
+      resetCustomCategoryForm();
       _isAddingCustomCategory = false;
-      _showCustomCategoryValidation = false;
     });
 
     await saveCustomCategories();
   }
 
+  void refreshCustomCategoryTitleOptions(
+      TextEditingController textEditingController) {
+    final value = textEditingController.value;
+    final offset = value.selection.isValid
+        ? value.selection.baseOffset.clamp(0, value.text.length).toInt()
+        : value.text.length;
+    final nextAffinity = value.selection.affinity == TextAffinity.downstream
+        ? TextAffinity.upstream
+        : TextAffinity.downstream;
+
+    // Nudges RawAutocomplete to rebuild options when tapping unchanged text.
+    textEditingController.value = value.copyWith(
+      selection: TextSelection.collapsed(
+        offset: offset,
+        affinity: nextAffinity,
+      ),
+    );
+  }
+
   Widget buildCustomCategoryTitleField() {
     return RawAutocomplete<String>(
+      key: ValueKey(
+          'custom-category-title-autocomplete-$_customCategoryFormGeneration'),
       textEditingController: _customCategoryTitleController,
       focusNode: _customCategoryTitleFocusNode,
       displayStringForOption: (option) => option,
       optionsBuilder: (TextEditingValue textEditingValue) {
         final input = textEditingValue.text.trim();
         final options = predefinedCategoryTitles();
-        if (input.isEmpty) {
+        final editingIndex = _editingCustomCategoryIndex;
+        final isInitialEditingTitle = editingIndex != null &&
+            editingIndex >= 0 &&
+            editingIndex < _customCategories.length &&
+            _customCategories[editingIndex].key == input;
+        if (input.isEmpty || isInitialEditingTitle) {
           return options;
         }
         return options.where((option) => option.contains(input));
@@ -184,23 +255,22 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
       },
       fieldViewBuilder:
           (context, textEditingController, focusNode, onFieldSubmitted) {
-            return TextField(
-              key: const Key('custom-category-title-field'),
-              controller: textEditingController,
-              focusNode: focusNode,
-              textDirection: appLocale.textDirection == 'rtl'
-                  ? TextDirection.rtl
-                  : null,
-              decoration: InputDecoration(
-                labelText: appLocale.sharePageCustomCategoryTitle,
-                errorText:
-                    _showCustomCategoryValidation &&
-                        _customCategoryTitleController.text.trim().isEmpty
-                    ? appLocale.validateEmpty
-                    : null,
-              ),
-            );
-          },
+        return TextField(
+          key: const Key('custom-category-title-field'),
+          controller: textEditingController,
+          focusNode: focusNode,
+          textDirection:
+              appLocale.textDirection == 'rtl' ? TextDirection.rtl : null,
+          onTap: () => refreshCustomCategoryTitleOptions(textEditingController),
+          decoration: InputDecoration(
+            labelText: appLocale.sharePageCustomCategoryTitle,
+            errorText: _showCustomCategoryValidation &&
+                    _customCategoryTitleController.text.trim().isEmpty
+                ? appLocale.validateEmpty
+                : null,
+          ),
+        );
+      },
       optionsViewBuilder: (context, onSelected, options) {
         return Align(
           alignment: Alignment.topLeft,
@@ -249,15 +319,13 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
             controller: _customCategoryDescriptionController,
             minLines: 3,
             maxLines: 6,
-            textDirection: appLocale.textDirection == 'rtl'
-                ? TextDirection.rtl
-                : null,
+            textDirection:
+                appLocale.textDirection == 'rtl' ? TextDirection.rtl : null,
             decoration: InputDecoration(
               labelText: appLocale.sharePageCustomCategoryDescription,
               alignLabelWithHint: true,
               border: const OutlineInputBorder(),
-              errorText:
-                  _showCustomCategoryValidation &&
+              errorText: _showCustomCategoryValidation &&
                       _customCategoryDescriptionController.text.trim().isEmpty
                   ? appLocale.validateEmpty
                   : null,
@@ -265,7 +333,7 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
           ),
           const SizedBox(height: 12),
           TextButton(
-            onPressed: addCustomCategory,
+            onPressed: saveCustomCategory,
             style: myButtonStyle,
             child: myAutoSizedText(
               appLocale.sharePageSaveCustomCategory,
@@ -279,7 +347,8 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
     );
   }
 
-  Widget buildCustomCategoryCard(MapEntry<String, String> category) {
+  Widget buildCustomCategoryCard(
+      MapEntry<String, String> category, int index, String gender) {
     return Container(
       width: MediaQuery.sizeOf(context).width > 1000
           ? 600
@@ -296,14 +365,32 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text(
-              category.key,
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16.sp,
-                fontFamily: 'Rubix',
-              ),
-              textAlign: textAlignFor(category.key),
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    category.key,
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16.sp,
+                      fontFamily: 'Rubix',
+                    ),
+                    textAlign: textAlignFor(category.key),
+                  ),
+                ),
+                IconButton(
+                  key: Key('custom-category-edit-button-$index'),
+                  tooltip: appLocale.addFormEdit(gender),
+                  icon: const Icon(Icons.edit, size: 20),
+                  onPressed: () => editCustomCategory(index),
+                ),
+                IconButton(
+                  key: Key('custom-category-delete-button-$index'),
+                  tooltip: appLocale.deleteButton(gender),
+                  icon: const Icon(Icons.delete, size: 20),
+                  onPressed: () => deleteCustomCategory(index),
+                ),
+              ],
             ),
             const SizedBox(height: 8),
             Directionality(
@@ -320,10 +407,11 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
     );
   }
 
-  Widget buildCustomCategoriesSection(BuildContext context) {
+  Widget buildCustomCategoriesSection(BuildContext context, String gender) {
     return Column(
       children: [
-        ..._customCategories.map(buildCustomCategoryCard),
+        ..._customCategories.asMap().entries.map(
+            (entry) => buildCustomCategoryCard(entry.value, entry.key, gender)),
         if (_isAddingCustomCategory) buildCustomCategoryForm(context),
         if (!_isAddingCustomCategory)
           TextButton(
@@ -481,6 +569,8 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
                   ),
                 ),
                 const SizedBox(height: 30),
+                buildCustomCategoriesSection(context, gender),
+                const SizedBox(height: 16),
                 ConfirmationButton(
                   context,
                   () {
@@ -492,8 +582,6 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
                     fontSize: 22.sp,
                   ),
                 ),
-                const SizedBox(height: 16),
-                buildCustomCategoriesSection(context),
                 const SizedBox(height: 30),
               ],
             ),

--- a/lib/form/shareform.dart
+++ b/lib/form/shareform.dart
@@ -208,6 +208,12 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
     await saveCustomCategories();
   }
 
+  String? _customCategoryValidationError(TextEditingController controller) {
+    return _showCustomCategoryValidation && controller.text.trim().isEmpty
+        ? appLocale.validateEmpty
+        : null;
+  }
+
   void refreshCustomCategoryTitleOptions(
       TextEditingController textEditingController) {
     final value = textEditingController.value;
@@ -264,10 +270,8 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
           onTap: () => refreshCustomCategoryTitleOptions(textEditingController),
           decoration: InputDecoration(
             labelText: appLocale.sharePageCustomCategoryTitle,
-            errorText: _showCustomCategoryValidation &&
-                    _customCategoryTitleController.text.trim().isEmpty
-                ? appLocale.validateEmpty
-                : null,
+            errorText:
+                _customCategoryValidationError(_customCategoryTitleController),
           ),
         );
       },
@@ -325,10 +329,8 @@ class _ShareFormState extends LPExtendedState<ShareForm> {
               labelText: appLocale.sharePageCustomCategoryDescription,
               alignLabelWithHint: true,
               border: const OutlineInputBorder(),
-              errorText: _showCustomCategoryValidation &&
-                      _customCategoryDescriptionController.text.trim().isEmpty
-                  ? appLocale.validateEmpty
-                  : null,
+              errorText: _customCategoryValidationError(
+                  _customCategoryDescriptionController),
             ),
           ),
           const SizedBox(height: 12),

--- a/test/form/shareform_test.dart
+++ b/test/form/shareform_test.dart
@@ -205,6 +205,18 @@ void main() {
     // This can be verified by checking navigation or other state changes
   });
 
+  testWidgets('ShareForm places the finish button below custom categories',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(createTestWidget());
+    await tester.ensureVisible(find.text('+ הוספת קטגוריה'));
+    await tester.pumpAndSettle();
+
+    final addCategoryTop = tester.getTopLeft(find.text('+ הוספת קטגוריה')).dy;
+    final finishTop = tester.getTopLeft(find.text('סיימתי!')).dy;
+
+    expect(finishTop, greaterThan(addCategoryTop));
+  });
+
   testWidgets('ShareForm adds multiple custom categories in original text',
       (WidgetTester tester) async {
     await tester.pumpWidget(createTestWidget());
@@ -251,6 +263,109 @@ void main() {
       'customCategoryDescriptions',
       PersistentMemoryType.StringList,
       ['טקסט חופשי בעברית שלא מתורגם', 'English text remains English'],
+    )).called(1);
+  });
+
+  testWidgets('ShareForm shows title suggestions when adding another category',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(createTestWidget());
+
+    await tester.ensureVisible(find.text('+ הוספת קטגוריה'));
+    await tester.tap(find.text('+ הוספת קטגוריה'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.byKey(const Key('custom-category-title-field')), 'קטגוריה ראשונה');
+    await tester.enterText(
+        find.byKey(const Key('custom-category-description-field')),
+        'תיאור ראשון');
+    await tester.ensureVisible(find.text('הוספת קטגוריה'));
+    await tester.tap(find.text('הוספת קטגוריה'));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(find.text('+ הוספת קטגוריה'));
+    await tester.tap(find.text('+ הוספת קטגוריה'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('custom-category-title-field')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('משפטים מחזקים שחשוב לי לזכור'), findsOneWidget);
+    expect(find.text('אירועים מהעבר לתזכורת'), findsOneWidget);
+    expect(find.text('דברים עלי שחשוב לי שנזכור'), findsOneWidget);
+    expect(find.text('אפשרות לכתוב משהו מקורי משלי'), findsOneWidget);
+  });
+
+  testWidgets('ShareForm edits and deletes saved custom categories',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(createTestWidget());
+
+    await tester.ensureVisible(find.text('+ הוספת קטגוריה'));
+    await tester.tap(find.text('+ הוספת קטגוריה'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.byKey(const Key('custom-category-title-field')), 'כותרת לעריכה');
+    await tester.enterText(
+        find.byKey(const Key('custom-category-description-field')),
+        'תיאור לעריכה');
+    await tester.ensureVisible(find.text('הוספת קטגוריה'));
+    await tester.tap(find.text('הוספת קטגוריה'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('custom-category-edit-button-0')));
+    await tester.pumpAndSettle();
+
+    final titleField = find.byKey(const Key('custom-category-title-field'));
+    final descriptionField =
+        find.byKey(const Key('custom-category-description-field'));
+    expect(
+        tester.widget<TextField>(titleField).controller?.text, 'כותרת לעריכה');
+    expect(tester.widget<TextField>(descriptionField).controller?.text,
+        'תיאור לעריכה');
+
+    await tester.tap(titleField);
+    await tester.pumpAndSettle();
+    expect(find.text('משפטים מחזקים שחשוב לי לזכור'), findsOneWidget);
+    expect(find.text('אירועים מהעבר לתזכורת'), findsOneWidget);
+    expect(find.text('דברים עלי שחשוב לי שנזכור'), findsOneWidget);
+    expect(find.text('אפשרות לכתוב משהו מקורי משלי'), findsOneWidget);
+
+    await tester.enterText(titleField, 'כותרת אחרי עריכה');
+    await tester.enterText(descriptionField, 'תיאור אחרי עריכה');
+    await tester.ensureVisible(find.text('הוספת קטגוריה'));
+    await tester.tap(find.text('הוספת קטגוריה'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('כותרת לעריכה'), findsNothing);
+    expect(find.text('תיאור לעריכה'), findsNothing);
+    expect(find.text('כותרת אחרי עריכה'), findsOneWidget);
+    expect(find.text('תיאור אחרי עריכה'), findsOneWidget);
+    verify(mockPersistentMemoryService.setItem(
+      'customCategoryTitles',
+      PersistentMemoryType.StringList,
+      ['כותרת אחרי עריכה'],
+    )).called(1);
+    verify(mockPersistentMemoryService.setItem(
+      'customCategoryDescriptions',
+      PersistentMemoryType.StringList,
+      ['תיאור אחרי עריכה'],
+    )).called(1);
+
+    await tester.tap(find.byKey(const Key('custom-category-delete-button-0')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('כותרת אחרי עריכה'), findsNothing);
+    expect(find.text('תיאור אחרי עריכה'), findsNothing);
+    expect(find.text('+ הוספת קטגוריה'), findsOneWidget);
+    verify(mockPersistentMemoryService.setItem(
+      'customCategoryTitles',
+      PersistentMemoryType.StringList,
+      <String>[],
+    )).called(1);
+    verify(mockPersistentMemoryService.setItem(
+      'customCategoryDescriptions',
+      PersistentMemoryType.StringList,
+      <String>[],
     )).called(1);
   });
 


### PR DESCRIPTION
# User description
## Summary
- Fixes the issue #253 follow-up feedback for custom categories in the Personal Plan final share/update flow.
- Keeps dropdown title suggestions available on every add/edit session, including after the first category is saved.
- Moves the `סיימתי!` finish button below the custom-category section and adds edit/delete controls for saved custom categories.
- Adds a reusable manual regression testing guide for high-risk app flows.

## Issue
Fixes #253.

## Root Cause
The custom-category form reused the same title controller and autocomplete state across repeated add attempts. After the first save, reopening the add form did not reliably recreate the title suggestion overlay, so users could type a custom title but no longer saw the predefined dropdown choices. Existing saved categories also had no edit/delete surface.

## Validation
- `flutter test test/form/shareform_test.dart`
- `flutter test test/file_service_custom_categories_test.dart test/personal_plan_custom_categories_test.dart`
- `flutter test integration_test/custom_categories_e2e_test.dart -d emulator-5554`
- `git diff --check`
- `flutter analyze lib/form/shareform.dart test/form/shareform_test.dart integration_test/custom_categories_e2e_test.dart` reports only the known preexisting ShareForm warnings.

## Manual QA Notes
- See `docs/manual-regression-test-guide.md` for the manual regression pass.
- Custom-category manual focus: add a first category, add a second category without leaving the page, confirm dropdown suggestions still appear, edit a saved category, delete a saved category, restart, and confirm persistence.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhance the <code>ShareForm</code> custom category workflow by ensuring dropdown titles reappear, wiring up edit/delete controls, and relocating the <code>סיימתי!</code> button below the saved categories. Add regression guidance and update the relevant widget/e2e tests to protect the new behavior while keeping persistence in sync.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/288?tool=ast&topic=Regression+Guide>Regression Guide</a>
        </td><td>Provide a reusable regression checklist for high-risk UI, navigation, persistence, locale, notification, and Personal Plan changes targeting the Android emulator plus optional web checks.<details><summary>Modified files (1)</summary><ul><li>docs/manual-regression-test-guide.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>Fix custom category fo...</td><td>June 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/288?tool=ast&topic=Custom+Category+Flow>Custom Category Flow</a>
        </td><td>Improve custom_category flow so saved items can be edited or deleted, dropdown suggestions always show, and the finish button sits below the custom-category section while tests and e2e coverage verify the experience.<details><summary>Modified files (3)</summary><ul><li>integration_test/custom_categories_e2e_test.dart</li>
<li>lib/form/shareform.dart</li>
<li>test/form/shareform_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>Refactor custom catego...</td><td>June 07, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Fix Flutter analyzer i...</td><td>May 31, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/288?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>