### PR TITLE
fix(menu): update localized share and contact URLs

### DIFF
--- a/lib/main_menu_dialog.dart
+++ b/lib/main_menu_dialog.dart
@@ -9,9 +9,16 @@ import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 const _hebrewContactUsUrl =
-    'https://sites.google.com/mishol.org/matzilon/%D7%AA%D7%9E%D7%99%D7%9B%D7%94';
-const _englishContactUsUrl =
-    'https://sites.google.com/mishol.org/living-positively/support';
+    'https://hebsite.livepositively.club/%D7%AA%D7%9E%D7%99%D7%9B%D7%94';
+const _englishContactUsUrl = 'https://engsite.livepositively.club/support';
+const _hebrewShareAppUrl = 'https://hebsite.livepositively.club';
+const _englishShareAppUrl = 'https://engsite.livepositively.club';
+
+String _shareAppUrl(AppLocalizations appLocale) {
+  return appLocale.localeName.startsWith('he')
+      ? _hebrewShareAppUrl
+      : _englishShareAppUrl;
+}
 
 String _contactUsUrl(AppLocalizations appLocale) {
   return appLocale.localeName.startsWith('he')
@@ -168,7 +175,7 @@ void showMainMenuDialog({
                       await SharePlus.instance.share(
                         ShareParams(
                           text:
-                              '${appLocale.shareAppMessage}\n https://sites.google.com/mishol.org/matzilon/%D7%91%D7%99%D7%AA',
+                              '${appLocale.shareAppMessage}\n ${_shareAppUrl(appLocale)}',
                           subject: 'Living Positively App',
                         ),
                       );

--- a/test/MenuTest/reminder_visibility_test.dart
+++ b/test/MenuTest/reminder_visibility_test.dart
@@ -317,7 +317,7 @@ void main() {
 
     expect(
       fakePlatform.lastLaunchedUrl,
-      'https://sites.google.com/mishol.org/matzilon/%D7%AA%D7%9E%D7%99%D7%9B%D7%94',
+      'https://hebsite.livepositively.club/%D7%AA%D7%9E%D7%99%D7%9B%D7%94',
     );
     expect(
       fakePlatform.lastLaunchOptions?.mode,
@@ -348,7 +348,7 @@ void main() {
 
     expect(
       fakePlatform.lastLaunchedUrl,
-      'https://sites.google.com/mishol.org/living-positively/support',
+      'https://engsite.livepositively.club/support',
     );
     expect(
       fakePlatform.lastLaunchOptions?.mode,

--- a/test/main_menu_dialog_test.dart
+++ b/test/main_menu_dialog_test.dart
@@ -22,7 +22,7 @@ import 'helpers/widget_test_scaffold.dart';
 const MethodChannel _shareChannel = MethodChannel(
   'dev.fluttercommunity.plus/share',
 );
-const _oldGoogleSitesShareBase = 'https://sites.google.com/mishol.org';
+const _shareSubject = 'Living Positively App';
 
 PhonePageData _phoneData() => PhonePageData(
       key: 'phone',
@@ -116,6 +116,10 @@ Future<Map<String, dynamic>> _sharePayloadFromMenu(
   expect(shareCalls, hasLength(1));
   expect(shareCalls.single.method, 'share');
   return Map<String, dynamic>.from(shareCalls.single.arguments as Map);
+}
+
+String _expectedShareText(Locale locale, String url) {
+  return '${lookupAppLocalizations(locale).shareAppMessage}\n $url';
 }
 
 void main() {
@@ -298,26 +302,34 @@ void main() {
     await tester.pump(const Duration(milliseconds: 50));
   });
 
-  testWidgets('Share button includes Hebrew app URL for Hebrew locale', (
-    tester,
-  ) async {
+  testWidgets('Share button includes Hebrew app URL for Hebrew locale',
+      (tester) async {
+    const locale = Locale('he');
     final payload = await _sharePayloadFromMenu(
       tester,
-      locale: const Locale('he'),
+      locale: locale,
     );
 
-    final sharedText = payload['text'] as String;
-    expect(sharedText, contains('https://hebsite.livepositively.club'));
-    expect(sharedText, isNot(contains(_oldGoogleSitesShareBase)));
+    expect(
+      payload['text'],
+      equals(
+        _expectedShareText(locale, 'https://hebsite.livepositively.club'),
+      ),
+    );
+    expect(payload['subject'], equals(_shareSubject));
   });
 
-  testWidgets('Share button includes English app URL for English locale', (
-    tester,
-  ) async {
+  testWidgets('Share button includes English app URL for English locale',
+      (tester) async {
+    const locale = Locale('en');
     final payload = await _sharePayloadFromMenu(tester);
 
-    final sharedText = payload['text'] as String;
-    expect(sharedText, contains('https://engsite.livepositively.club'));
-    expect(sharedText, isNot(contains(_oldGoogleSitesShareBase)));
+    expect(
+      payload['text'],
+      equals(
+        _expectedShareText(locale, 'https://engsite.livepositively.club'),
+      ),
+    );
+    expect(payload['subject'], equals(_shareSubject));
   });
 }

--- a/test/main_menu_dialog_test.dart
+++ b/test/main_menu_dialog_test.dart
@@ -19,6 +19,11 @@ import 'package:mazilon/util/userInformation.dart';
 
 import 'helpers/widget_test_scaffold.dart';
 
+const MethodChannel _shareChannel = MethodChannel(
+  'dev.fluttercommunity.plus/share',
+);
+const _oldGoogleSitesShareBase = 'https://sites.google.com/mishol.org';
+
 PhonePageData _phoneData() => PhonePageData(
       key: 'phone',
       header: 'h',
@@ -38,10 +43,11 @@ Future<void> _openMenu(
   required bool isWeb,
   required VoidCallback onAbout,
   required VoidCallback onNotifications,
+  Locale locale = const Locale('en'),
 }) async {
   final user = UserInformation()
     ..gender = 'other'
-    ..localeName = 'en';
+    ..localeName = locale.languageCode;
   final phone = _phoneData();
   await pumpWithProviders(
     tester,
@@ -69,8 +75,47 @@ Future<void> _openMenu(
       );
     }),
     userInformation: user,
+    locale: locale,
     surfaceSize: const Size(1024, 800),
   );
+}
+
+Future<Map<String, dynamic>> _sharePayloadFromMenu(
+  WidgetTester tester, {
+  Locale locale = const Locale('en'),
+}) async {
+  final shareCalls = <MethodCall>[];
+  tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    _shareChannel,
+    (call) async {
+      shareCalls.add(call);
+      return null;
+    },
+  );
+
+  await _openMenu(
+    tester,
+    isWeb: false,
+    onAbout: () {},
+    onNotifications: () {},
+    locale: locale,
+  );
+  await tester.tap(find.byKey(const Key('openMenu')));
+  await tester.pumpAndSettle();
+
+  final shareButton = tester.widget<TextButton>(
+    find.ancestor(
+      of: find.byIcon(Icons.share),
+      matching: find.byType(TextButton),
+    ),
+  );
+  shareButton.onPressed!();
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+
+  expect(shareCalls, hasLength(1));
+  expect(shareCalls.single.method, 'share');
+  return Map<String, dynamic>.from(shareCalls.single.arguments as Map);
 }
 
 void main() {
@@ -83,7 +128,7 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized()
         .defaultBinaryMessenger
         .setMockMethodCallHandler(
-      const MethodChannel('dev.fluttercommunity.plus/share'),
+      _shareChannel,
       (call) async => null,
     );
   });
@@ -251,5 +296,28 @@ void main() {
     shareButton.onPressed!();
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
+  });
+
+  testWidgets('Share button includes Hebrew app URL for Hebrew locale', (
+    tester,
+  ) async {
+    final payload = await _sharePayloadFromMenu(
+      tester,
+      locale: const Locale('he'),
+    );
+
+    final sharedText = payload['text'] as String;
+    expect(sharedText, contains('https://hebsite.livepositively.club'));
+    expect(sharedText, isNot(contains(_oldGoogleSitesShareBase)));
+  });
+
+  testWidgets('Share button includes English app URL for English locale', (
+    tester,
+  ) async {
+    final payload = await _sharePayloadFromMenu(tester);
+
+    final sharedText = payload['text'] as String;
+    expect(sharedText, contains('https://engsite.livepositively.club'));
+    expect(sharedText, isNot(contains(_oldGoogleSitesShareBase)));
   });
 }


### PR DESCRIPTION
# User description
## Summary
- Updates the main menu Share URL to use the new shortened Hebrew or English site URL based on the active app locale.
- Updates the Contact Us URL mapping to the new shortened Hebrew and English support URLs.
- Adds focused widget coverage for the Share URL payload and updates Contact Us URL expectations.

## URL mappings
- Hebrew Share: `https://hebsite.livepositively.club`
- English Share: `https://engsite.livepositively.club`
- Hebrew Contact Us: `https://hebsite.livepositively.club/%D7%AA%D7%9E%D7%99%D7%9B%D7%94`
- English Contact Us: `https://engsite.livepositively.club/support`

Fixes #291

## Verification
- `flutter test test/main_menu_dialog_test.dart test/MenuTest/reminder_visibility_test.dart` passed.
- `flutter analyze lib/main_menu_dialog.dart test/main_menu_dialog_test.dart test/MenuTest/reminder_visibility_test.dart` passed.
- `flutter analyze` was also run and reported an existing unrelated warning in `lib/main.dart:76` (`unawaited_return_in_try_block`); this branch does not touch that file.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the main menu dialog to map Share and Contact actions to the new Hebrew and English shortened domains via locale-aware helpers within AppLocalizations. Verify the share payload generation and contact link expectations in the menu tests for both locales.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/292?tool=ast&topic=Localized+URLs>Localized URLs</a>
        </td><td>Update the main menu to send Share and Contact requests to the new Hebrew/English shortened domains using locale-aware helpers that wrap <code>AppLocalizations</code>.<details><summary>Modified files (2)</summary><ul><li>lib/main_menu_dialog.dart</li>
<li>test/MenuTest/reminder_visibility_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(menu): update loca...</td><td>June 26, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Fix RTL layout regress...</td><td>May 28, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/292?tool=ast&topic=Share+URL+Tests>Share URL Tests</a>
        </td><td>Add share widget helpers to ensure the Share payload includes the locale-specific URLs and subject expected by users.<details><summary>Modified files (1)</summary><ul><li>test/main_menu_dialog_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>test(menu): tighten sh...</td><td>June 26, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>increased coverage to 85%</td><td>May 18, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/292?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>