### PR TITLE
feat(sos): add ERAN and SAHAR support details

### DIFF
--- a/lib/EmergencyNumbers.dart
+++ b/lib/EmergencyNumbers.dart
@@ -67,7 +67,7 @@ final Map<String, Country> countries = {
       "number": "1201",
       "whatsappNumber": "972528451201",
       "link": "",
-      "description": "טלפון-1201/מחו\"ל-*2201 | שלוחה 5",
+      "description": "עזרה ראשונה נפשית",
       "icon": Icons.phone,
       "whatsapp": true,
       "canCall": true,
@@ -75,7 +75,7 @@ final Map<String, Country> countries = {
     {
       "name": "סה\"ר",
       "number": "0559571399",
-      "link": "",
+      "link": "https://sahar.org.il/",
       "description": "סיוע והקשבה ברשת",
       "icon": Icons.phone,
       "whatsapp": true,

--- a/lib/MainPageHelpers/personalPlanWidget.dart
+++ b/lib/MainPageHelpers/personalPlanWidget.dart
@@ -214,11 +214,7 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
                               2,
                             ),
                           ),
-                          Icon(
-                            appLocale.textDirection == "rtl"
-                                ? Icons.arrow_left
-                                : Icons.arrow_right,
-                          ),
+                          const Icon(Icons.arrow_right),
                         ],
                       ),
                     ),

--- a/lib/main_menu_dialog.dart
+++ b/lib/main_menu_dialog.dart
@@ -103,13 +103,6 @@ void showMainMenuDialog({
                 children: <Widget>[
                   Row(
                     children: [
-                      IconButton(
-                        key: const Key('mainMenuCloseButton'),
-                        icon: const Icon(Icons.close),
-                        onPressed: () {
-                          Navigator.of(context).pop();
-                        },
-                      ),
                       Expanded(
                         child: Align(
                           alignment: AlignmentDirectional.centerStart,
@@ -128,6 +121,13 @@ void showMainMenuDialog({
                             },
                           ),
                         ),
+                      ),
+                      IconButton(
+                        key: const Key('mainMenuCloseButton'),
+                        icon: const Icon(Icons.close),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
                       ),
                     ],
                   ),

--- a/lib/main_menu_dialog.dart
+++ b/lib/main_menu_dialog.dart
@@ -94,15 +94,10 @@ void showMainMenuDialog({
       final aboutButton = Expanded(
         child: Align(
           alignment: AlignmentDirectional.centerStart,
-          child: TextButton(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.people),
-                const SizedBox(width: 20),
-                Text(appLocale.homePageAbout(gender)),
-              ],
-            ),
+          child: _buildMainMenuAction(
+            icon: Icons.people,
+            label: appLocale.homePageAbout(gender),
+            mainAxisSize: MainAxisSize.min,
             onPressed: () {
               onAboutPressed();
               Navigator.of(context).pop();
@@ -141,15 +136,9 @@ void showMainMenuDialog({
                     isWeb: isWeb,
                     onNotificationsPressed: onNotificationsPressed,
                   ),
-                  TextButton(
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        const Icon(Icons.settings),
-                        const SizedBox(width: 20),
-                        Text(appLocale.settings(gender)),
-                      ],
-                    ),
+                  _buildMainMenuAction(
+                    icon: Icons.settings,
+                    label: appLocale.settings(gender),
                     onPressed: () {
                       Navigator.of(context).pop();
                       Navigator.push(
@@ -165,15 +154,9 @@ void showMainMenuDialog({
                       );
                     },
                   ),
-                  TextButton(
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        const Icon(Icons.share),
-                        const SizedBox(width: 20),
-                        Text(appLocale.shareButtonText),
-                      ],
-                    ),
+                  _buildMainMenuAction(
+                    icon: Icons.share,
+                    label: appLocale.shareButtonText,
                     onPressed: () async {
                       await SharePlus.instance.share(
                         ShareParams(
@@ -184,16 +167,10 @@ void showMainMenuDialog({
                       );
                     },
                   ),
-                  TextButton(
+                  _buildMainMenuAction(
                     key: const Key('mainMenuContactUsButton'),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        const Icon(Icons.email),
-                        const SizedBox(width: 20),
-                        Text(appLocale.contactUs),
-                      ],
-                    ),
+                    icon: Icons.email,
+                    label: appLocale.contactUs,
                     onPressed: () async {
                       await _openContactUs(appLocale);
                     },
@@ -208,6 +185,24 @@ void showMainMenuDialog({
   );
 }
 
+Widget _buildMainMenuAction({
+  Key? key,
+  required IconData icon,
+  required String label,
+  required VoidCallback onPressed,
+  MainAxisSize mainAxisSize = MainAxisSize.max,
+}) {
+  return TextButton(
+    key: key,
+    onPressed: onPressed,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      mainAxisSize: mainAxisSize,
+      children: [Icon(icon), const SizedBox(width: 20), Text(label)],
+    ),
+  );
+}
+
 Widget _notificationButton({
   required BuildContext context,
   required AppLocalizations appLocale,
@@ -219,15 +214,9 @@ Widget _notificationButton({
     return const SizedBox.shrink();
   }
 
-  return TextButton(
-    child: Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        const Icon(Icons.notification_add),
-        const SizedBox(width: 20),
-        Text(appLocale.notifications(gender)),
-      ],
-    ),
+  return _buildMainMenuAction(
+    icon: Icons.notification_add,
+    label: appLocale.notifications(gender),
     onPressed: () {
       onNotificationsPressed();
       Navigator.of(context).pop();

--- a/lib/main_menu_dialog.dart
+++ b/lib/main_menu_dialog.dart
@@ -84,6 +84,33 @@ void showMainMenuDialog({
     transitionDuration: const Duration(milliseconds: 200),
     pageBuilder: (BuildContext buildContext, Animation<double> animation,
         Animation<double> secondaryAnimation) {
+      final closeButton = IconButton(
+        key: const Key('mainMenuCloseButton'),
+        icon: const Icon(Icons.close),
+        onPressed: () {
+          Navigator.of(context).pop();
+        },
+      );
+      final aboutButton = Expanded(
+        child: Align(
+          alignment: AlignmentDirectional.centerStart,
+          child: TextButton(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.people),
+                const SizedBox(width: 20),
+                Text(appLocale.homePageAbout(gender)),
+              ],
+            ),
+            onPressed: () {
+              onAboutPressed();
+              Navigator.of(context).pop();
+            },
+          ),
+        ),
+      );
+
       return Stack(
         children: [
           Positioned(
@@ -102,34 +129,10 @@ void showMainMenuDialog({
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   Row(
-                    children: [
-                      Expanded(
-                        child: Align(
-                          alignment: AlignmentDirectional.centerStart,
-                          child: TextButton(
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const Icon(Icons.people),
-                                const SizedBox(width: 20),
-                                Text(appLocale.homePageAbout(gender)),
-                              ],
-                            ),
-                            onPressed: () {
-                              onAboutPressed();
-                              Navigator.of(context).pop();
-                            },
-                          ),
-                        ),
-                      ),
-                      IconButton(
-                        key: const Key('mainMenuCloseButton'),
-                        icon: const Icon(Icons.close),
-                        onPressed: () {
-                          Navigator.of(context).pop();
-                        },
-                      ),
-                    ],
+                    textDirection: TextDirection.ltr,
+                    children: isRtl
+                        ? [closeButton, aboutButton]
+                        : [aboutButton, closeButton],
                   ),
                   _notificationButton(
                     context: context,

--- a/lib/util/Phone/emergencyDialogBox.dart
+++ b/lib/util/Phone/emergencyDialogBox.dart
@@ -53,11 +53,9 @@ class EmergencyDialogBox extends StatelessWidget {
       content: SingleChildScrollView(
         child: ListBody(
           children: <Widget>[
-            Wrap(
-              alignment: WrapAlignment.center,
-              runAlignment: WrapAlignment.center,
-              spacing: 12,
-              runSpacing: 12,
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
                 if (canCall)
                   getTextIconWidget(
@@ -70,6 +68,7 @@ class EmergencyDialogBox extends StatelessWidget {
                     ),
                     Icons.phone,
                   ),
+                if (canCall) const SizedBox(height: 12),
                 if (hasText)
                   getTextIconWidget(
                     'Text',
@@ -82,6 +81,7 @@ class EmergencyDialogBox extends StatelessWidget {
                     ),
                     Icons.sms,
                   ),
+                if (hasText) const SizedBox(height: 12),
                 if (hasWhatsApp)
                   getTextIconWidget(
                     appLocale.whatsApp,
@@ -93,6 +93,7 @@ class EmergencyDialogBox extends StatelessWidget {
                     ),
                     Icons.chat,
                   ),
+                if (hasWhatsApp && hasLink) const SizedBox(height: 12),
                 if (hasLink)
                   getTextIconWidget(
                     isChatLink ? 'Chat' : appLocale.link,

--- a/lib/util/Phone/phoneTextAndIcon.dart
+++ b/lib/util/Phone/phoneTextAndIcon.dart
@@ -207,14 +207,17 @@ Future<bool> openTextMessage(String number, {String body = ''}) {
 Widget getTextIconWidget(String text, Function onClick, IconData icon) {
   return SizedBox(
     child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        myText(
-          text,
-          TextStyle(
-            fontWeight: FontWeight.normal,
-            fontSize: 18.sp > 35 ? 35 : 20.sp,
+        Flexible(
+          child: myText(
+            text,
+            TextStyle(
+              fontWeight: FontWeight.normal,
+              fontSize: 18.sp > 35 ? 35 : 20.sp,
+            ),
+            null,
           ),
-          null,
         ),
         SizedBox(width: 5.0),
         // Button to make a phone call. Tooltip carries the visible long-press

--- a/test/MainPageHelpers/personal_plan_widget_layout_test.dart
+++ b/test/MainPageHelpers/personal_plan_widget_layout_test.dart
@@ -106,6 +106,35 @@ void main() {
     expect(fullPlanCalls, 1);
   });
 
+  testWidgets('Hebrew view-all control uses right-pointing arrow', (
+    tester,
+  ) async {
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>['First item', 'Second item']),
+        changeCurrentIndex: (_, _) {},
+      ),
+      locale: const Locale('he'),
+      surfaceSize: const Size(700, 1200),
+    );
+
+    final button = find.byKey(const Key('personalPlanViewAllButton'));
+    expect(button, findsOneWidget);
+    expect(
+      find.descendant(of: button, matching: find.text('לכל התוכנית')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: button, matching: find.byIcon(Icons.arrow_right)),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: button, matching: find.byIcon(Icons.arrow_left)),
+      findsNothing,
+    );
+  });
+
   testWidgets('large Hebrew preview text does not overflow', (tester) async {
     await pumpWithProviders(
       tester,

--- a/test/MenuTest/Wellness/wellnessTools_test.dart
+++ b/test/MenuTest/Wellness/wellnessTools_test.dart
@@ -144,12 +144,12 @@ void main() {
       expect(menuDialogWidth, lessThanOrEqualTo(260));
       expect(
         closeButtonLeft,
-        greaterThan(menuDialogLeft + menuDialogWidth / 2),
-        reason: 'RTL header controls should start from the right edge.',
+        lessThan(menuDialogLeft + menuDialogWidth / 2),
+        reason: 'RTL close button should land on the left edge.',
       );
       expect((closeButtonCenterY - aboutIconCenterY).abs(), lessThan(8));
     });
-    testWidgets('Header menu puts close button on the left in English', (
+    testWidgets('Header menu puts close button on the right in English', (
       WidgetTester tester,
     ) async {
       tester.view.physicalSize = const Size(1200, 900);
@@ -182,8 +182,8 @@ void main() {
       expect(menuDialogTop - menuButtonBottom, lessThan(20));
       expect(
         closeButtonLeft,
-        lessThan(menuDialogLeft + menuDialogWidth / 2),
-        reason: 'LTR header controls should start from the left edge.',
+        greaterThan(menuDialogLeft + menuDialogWidth / 2),
+        reason: 'LTR close button should land on the right edge.',
       );
     });
     testWidgets('Navigate from WellnessTools screen', (

--- a/test/a11y/phase_c_rtl_test.dart
+++ b/test/a11y/phase_c_rtl_test.dart
@@ -173,15 +173,14 @@ void main() {
     }
 
     testWidgets(
-        'header Row no longer pins an inverted textDirection in he locale',
+        'header Row uses explicit physical ordering for the close button',
         (tester) async {
       await openMenu(tester, const Locale('he'));
 
-      // The header Row that holds the close (X) button used to set
-      // `textDirection: isRtl ? LTR : RTL` (UX_GAPS §1.4). Phase C drops
-      // that override so the Row inherits the ambient Directionality (RTL
-      // in `he`). We assert by walking up from the close button to the
-      // first Row ancestor and confirming the override is null.
+      // The close button side is a physical product requirement:
+      // English => right, Hebrew => left. Keep the header Row in physical
+      // LTR coordinates and choose child order from the active locale so
+      // the X does not depend on a route-level Directionality mismatch.
       final closeFinder = find.byKey(const Key('mainMenuCloseButton'));
       expect(closeFinder, findsOneWidget);
 
@@ -194,10 +193,11 @@ void main() {
       final headerRow = tester.widget<Row>(rowAncestor.first);
       expect(
         headerRow.textDirection,
-        isNull,
+        TextDirection.ltr,
         reason:
-            'main_menu_dialog header Row must not override textDirection — '
-            'Phase C removed the inverted `isRtl ? LTR : RTL` branch.',
+            'main_menu_dialog must place the close button using explicit '
+            'physical coordinates so locale, not inherited route direction, '
+            'decides whether the X is left or right.',
       );
     });
 

--- a/test/a11y/phase_c_rtl_test.dart
+++ b/test/a11y/phase_c_rtl_test.dart
@@ -201,6 +201,44 @@ void main() {
       );
     });
 
+    testWidgets('close button lands on the trailing edge in LTR', (
+      tester,
+    ) async {
+      await openMenu(tester, const Locale('en'));
+
+      final closeCenter = tester.getCenter(
+        find.byKey(const Key('mainMenuCloseButton')),
+      );
+      final dialogCenter = tester.getCenter(
+        find.byKey(const Key('mainMenuDialog')),
+      );
+
+      expect(
+        closeCenter.dx,
+        greaterThan(dialogCenter.dx),
+        reason: 'The main menu close button must sit on the right in English.',
+      );
+    });
+
+    testWidgets('close button flips to the trailing edge in RTL', (
+      tester,
+    ) async {
+      await openMenu(tester, const Locale('he'));
+
+      final closeCenter = tester.getCenter(
+        find.byKey(const Key('mainMenuCloseButton')),
+      );
+      final dialogCenter = tester.getCenter(
+        find.byKey(const Key('mainMenuDialog')),
+      );
+
+      expect(
+        closeCenter.dx,
+        lessThan(dialogCenter.dx),
+        reason: 'The main menu close button must sit on the left in Hebrew.',
+      );
+    });
+
     testWidgets(
         'About label aligns to leading edge via AlignmentDirectional',
         (tester) async {

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -143,6 +143,21 @@ void main() {
     expect(eran['number'], '1201');
     expect(eran['whatsapp'], true);
     expect(eran['whatsappNumber'], '972528451201');
+    expect(eran['description'], 'עזרה ראשונה נפשית');
+  });
+
+  test('Israel emergency numbers include Sahar description and website', () {
+    final israel = countries['israel'];
+    expect(israel, isNotNull);
+
+    final sahar = israel!.emergencyNumbers.firstWhere(
+      (entry) => entry['name'] == 'סה"ר',
+    );
+
+    expect(sahar['number'], '0559571399');
+    expect(sahar['whatsapp'], true);
+    expect(sahar['description'], 'סיוע והקשבה ברשת');
+    expect(sahar['link'], 'https://sahar.org.il/');
   });
 
   test('105 entry uses WhatsApp chat number 0521210105', () {
@@ -705,9 +720,13 @@ void main() {
     final eran = find.text(hebrewEran);
     final sahar = find.text(hebrewSahar);
     final number105 = find.text('105');
+    final eranDescription = find.text('עזרה ראשונה נפשית');
+    final saharDescription = find.text('סיוע והקשבה ברשת');
     expect(eran, findsOneWidget);
     expect(sahar, findsOneWidget);
     expect(number105, findsOneWidget);
+    expect(eranDescription, findsOneWidget);
+    expect(saharDescription, findsOneWidget);
 
     final eranTop = tester.getTopLeft(eran).dy;
     final saharTop = tester.getTopLeft(sahar).dy;
@@ -716,4 +735,55 @@ void main() {
     expect(saharTop, closeTo(eranTop, 1));
     expect(number105Top, greaterThan(eranTop + 20));
   });
+
+  testWidgets(
+    'Sahar website action appears below WhatsApp and opens the site',
+    (tester) async {
+      final originalPlatform = UrlLauncherPlatform.instance;
+      final fakePlatform = FakeUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fakePlatform;
+      addTearDown(() {
+        UrlLauncherPlatform.instance = originalPlatform;
+      });
+
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final userInfo = UserInformation(
+        gender: 'male',
+        location: 'IL',
+        service: FakePersistentMemoryService(),
+      );
+
+      await tester.pumpWidget(
+        buildEmergencyGridTestApp(
+          userInformation: userInfo,
+          locale: const Locale('he'),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(hebrewSahar));
+      await tester.pumpAndSettle();
+
+      final whatsAppAction = find.text('ווצאפ');
+      final websiteAction = find.text('קישור לאתר');
+      expect(whatsAppAction, findsOneWidget);
+      expect(websiteAction, findsOneWidget);
+
+      expect(
+        tester.getTopLeft(websiteAction).dy,
+        greaterThan(tester.getTopLeft(whatsAppAction).dy),
+      );
+
+      await tester.tap(find.byIcon(Icons.language));
+      await tester.pumpAndSettle();
+
+      expect(fakePlatform.lastLaunchedUrl, 'https://sahar.org.il/');
+    },
+  );
 }

--- a/test/l10n/rtl_layout_compliance_test.dart
+++ b/test/l10n/rtl_layout_compliance_test.dart
@@ -168,28 +168,27 @@ void main() {
       }
     });
 
-    testWidgets(
-      'PersonalPlanWidget does not use a physical right arrow under RTL',
-      (WidgetTester tester) async {
-        await pumpArabicHarness(
-          tester,
-          PersonalPlanWidget(
-            text: const {
-              'list': ['One', 'Two'],
-              'SubTitle': 'Subtitle',
-            },
-            changeCurrentIndex: (_, _) {},
-          ),
-        );
+    testWidgets('PersonalPlanWidget does not use a left arrow under RTL', (
+      WidgetTester tester,
+    ) async {
+      await pumpArabicHarness(
+        tester,
+        PersonalPlanWidget(
+          text: const {
+            'list': ['One', 'Two'],
+            'SubTitle': 'Subtitle',
+          },
+          changeCurrentIndex: (_, _) {},
+        ),
+      );
 
-        expect(
-          find.descendant(
-            of: find.byType(PersonalPlanWidget),
-            matching: find.byIcon(Icons.arrow_right),
-          ),
-          findsNothing,
-        );
-      },
-    );
+      expect(
+        find.descendant(
+          of: find.byType(PersonalPlanWidget),
+          matching: find.byIcon(Icons.arrow_left),
+        ),
+        findsNothing,
+      );
+    });
   });
 }


### PR DESCRIPTION
# User description
## Summary
- Updates the Israel SOS ERAN description to `עזרה ראשונה נפשית`.
- Adds the SAHAR website link `https://sahar.org.il/` while keeping the existing SAHAR description `סיוע והקשבה ברשת`.
- Stacks emergency dialog actions vertically with flexible action labels so the SAHAR website action appears below WhatsApp on Hebrew phone-width UI.

Fixes #220

## Verification
- `flutter test test\emergency_whatsapp_test.dart test\Phone\phoneTextAndIcon_test.dart test\Phone\launchFailureUI_test.dart` - passed, 40 tests.
- `flutter test` - passed, 719 tests, 8 skipped.
- `flutter analyze` - reports an existing warning in unchanged `lib\main.dart:76` (`unawaited_return_in_try_block`).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>EmergencyNumbers</code> and the emergency dialog flow to show the new ERAN description, add the SAHAR website link, and stack dialog actions vertically so the Hebrew emergency sheet keeps WhatsApp above the site link on narrow screens. Refactor the main menu header to use <code>_buildMainMenuAction</code> and explicit physical ordering so the close button lands on the locale-specific trailing edge with supporting RTL layout tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/293?tool=ast&topic=Emergency+actions>Emergency actions</a>
        </td><td>Describe emergency entries and dialog controls to render the new ERAN label, surface the <code>https://sahar.org.il/</code> link for SAHAR, and stack call/text/WhatsApp/website actions with centered labels so the Hebrew sheet shows the website action below WhatsApp.<details><summary>Modified files (4)</summary><ul><li>lib/EmergencyNumbers.dart</li>
<li>lib/util/Phone/emergencyDialogBox.dart</li>
<li>lib/util/Phone/phoneTextAndIcon.dart</li>
<li>test/emergency_whatsapp_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>feat(sos): add ERAN an...</td><td>June 28, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Fix Flutter analyzer i...</td><td>May 31, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/293?tool=ast&topic=Menu+layout>Menu layout</a>
        </td><td>Rebuild the main menu header into <code>_buildMainMenuAction</code>, enforce trailing-edge close-button placement via physical ordering, and align PersonalPlan arrow expectations through RTL-friendly layouts and tests.<details><summary>Modified files (6)</summary><ul><li>lib/MainPageHelpers/personalPlanWidget.dart</li>
<li>lib/main_menu_dialog.dart</li>
<li>test/MainPageHelpers/personal_plan_widget_layout_test.dart</li>
<li>test/MenuTest/Wellness/wellnessTools_test.dart</li>
<li>test/a11y/phase_c_rtl_test.dart</li>
<li>test/l10n/rtl_layout_compliance_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(plan): correct Heb...</td><td>June 28, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Implement UX gaps reme...</td><td>June 07, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/293?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>