### PR TITLE
[Enhancement LP 1.0] Add Elem support for under-18 SOS users

### DIFF
--- a/lib/EmergencyNumbers.dart
+++ b/lib/EmergencyNumbers.dart
@@ -16,6 +16,18 @@ class Country {
   });
 }
 
+const Map<String, dynamic> elemSupportOption = {
+  "name": "Elem עלם",
+  "number": "972546786776",
+  "whatsappNumber": "972546786776",
+  "link": "https://yelem.org.il/",
+  "description": "Support for children and teens",
+  "descriptionHe": "סיוע לילדים ובני נוער",
+  "icon": Icons.chat,
+  "whatsapp": true,
+  "canCall": false,
+};
+
 const List<String> euCountryCodes = [
   'AT',
   'BE',

--- a/lib/EmergencyNumbers.dart
+++ b/lib/EmergencyNumbers.dart
@@ -18,7 +18,7 @@ class Country {
 
 const Map<String, dynamic> elemSupportOption = {
   "name": "Elem עלם",
-  "number": "972546786776",
+  "number": "0546786776",
   "whatsappNumber": "972546786776",
   "link": "https://yelem.org.il/",
   "description": "Support for children and teens",

--- a/lib/util/Phone/EmergencyPhones.dart
+++ b/lib/util/Phone/EmergencyPhones.dart
@@ -50,14 +50,17 @@ class EmergencyPhonesGrid extends StatelessWidget {
     final activeCountry = country ?? defaultEmergencyCountry;
     final bool isFallback = country == null;
     final localNumbers = <Map<String, dynamic>>[
-      if (userInfo.age.trim() == '18-') elemSupportOption,
       ...activeCountry.emergencyNumbers,
     ];
     final appLocale = AppLocalizations.of(context);
-    final displayedNumbers =
+    final orderedNumbers =
         appLocale?.localeName == 'he' && activeCountry.id == 'israel'
             ? _hebrewIsraelEmergencyOrder(localNumbers)
             : localNumbers;
+    final displayedNumbers = <Map<String, dynamic>>[
+      ...orderedNumbers,
+      if (userInfo.age.trim() == '18-') elemSupportOption,
+    ];
 
     Widget? fallbackBanner;
     if (isFallback) {

--- a/lib/util/Phone/EmergencyPhones.dart
+++ b/lib/util/Phone/EmergencyPhones.dart
@@ -49,7 +49,10 @@ class EmergencyPhonesGrid extends StatelessWidget {
     }
     final activeCountry = country ?? defaultEmergencyCountry;
     final bool isFallback = country == null;
-    final localNumbers = activeCountry.emergencyNumbers;
+    final localNumbers = <Map<String, dynamic>>[
+      if (userInfo.age.trim() == '18-') elemSupportOption,
+      ...activeCountry.emergencyNumbers,
+    ];
     final appLocale = AppLocalizations.of(context);
     final displayedNumbers =
         appLocale?.localeName == 'he' && activeCountry.id == 'israel'

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -37,7 +37,10 @@ class FakePersistentMemoryService implements PersistentMemoryService {
 }
 
 class FakeUrlLauncherPlatform extends UrlLauncherPlatform {
-  String? lastLaunchedUrl;
+  final List<String> launchedUrls = [];
+
+  String? get lastLaunchedUrl =>
+      launchedUrls.isEmpty ? null : launchedUrls.last;
 
   @override
   LinkDelegate? get linkDelegate => null;
@@ -58,7 +61,7 @@ class FakeUrlLauncherPlatform extends UrlLauncherPlatform {
     required Map<String, String> headers,
     String? webOnlyWindowName,
   }) async {
-    lastLaunchedUrl = url;
+    launchedUrls.add(url);
     return true;
   }
 }
@@ -175,7 +178,12 @@ void main() {
 
   test('Elem support uses the requested WhatsApp number and website', () {
     expect(elemSupportOption['name'], 'Elem עלם');
+    expect(elemSupportOption['number'], '0546786776');
     expect(elemSupportOption['whatsappNumber'], '972546786776');
+    expect(
+      elemSupportOption['number'],
+      isNot(elemSupportOption['whatsappNumber']),
+    );
     expect(elemSupportOption['link'], 'https://yelem.org.il/');
     expect(elemSupportOption['whatsapp'], true);
     expect(elemSupportOption['canCall'], false);
@@ -193,7 +201,13 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Elem עלם'), findsOneWidget);
+    final emergency = find.text('Emergency');
+    final elem = find.text('Elem עלם');
+    expect(elem, findsOneWidget);
+    expect(
+      tester.getTopLeft(elem).dy,
+      greaterThan(tester.getTopLeft(emergency).dy),
+    );
 
     await tester.pumpWidget(
       buildEmergencyGridTestApp(
@@ -235,11 +249,14 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.chat).last);
     await tester.pumpAndSettle();
-    expect(fakePlatform.lastLaunchedUrl, 'https://wa.me/972546786776');
+    expect(fakePlatform.launchedUrls, ['https://wa.me/972546786776']);
 
     await tester.tap(find.byIcon(Icons.language));
     await tester.pumpAndSettle();
-    expect(fakePlatform.lastLaunchedUrl, 'https://yelem.org.il/');
+    expect(fakePlatform.launchedUrls, [
+      'https://wa.me/972546786776',
+      'https://yelem.org.il/',
+    ]);
   });
 
   test('Emergency numbers match SOS reference data for AU/US/UK/EU', () {

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -201,13 +201,23 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final emergency = find.text('Emergency');
-    final elem = find.text('Elem עלם');
-    expect(elem, findsOneWidget);
-    expect(
-      tester.getTopLeft(elem).dy,
-      greaterThan(tester.getTopLeft(emergency).dy),
-    );
+    const expectedNames = [
+      'Emergency',
+      'Veterans Crisis Line',
+      'The Trevor Project (for LGBTQ+ youth)',
+      '988 Suicide & Crisis Lifeline',
+      'Crisis Text Line',
+      'Elem עלם',
+    ];
+    for (final name in expectedNames) {
+      expect(find.text(name), findsOneWidget);
+    }
+
+    final renderedNames = tester
+        .widgetList<EmergencyPhoneItem>(find.byType(EmergencyPhoneItem))
+        .map((item) => item.number['name'] as String)
+        .toList();
+    expect(renderedNames, expectedNames);
 
     await tester.pumpWidget(
       buildEmergencyGridTestApp(

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -173,6 +173,75 @@ void main() {
     expect(entry105['whatsappNumber'], '0521210105');
   });
 
+  test('Elem support uses the requested WhatsApp number and website', () {
+    expect(elemSupportOption['name'], 'Elem עלם');
+    expect(elemSupportOption['whatsappNumber'], '972546786776');
+    expect(elemSupportOption['link'], 'https://yelem.org.il/');
+    expect(elemSupportOption['whatsapp'], true);
+    expect(elemSupportOption['canCall'], false);
+  });
+
+  testWidgets('Elem support is shown only to under-18 users', (tester) async {
+    await tester.pumpWidget(
+      buildEmergencyGridTestApp(
+        userInformation: UserInformation(
+          age: '18-',
+          location: 'US',
+          service: FakePersistentMemoryService(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Elem עלם'), findsOneWidget);
+
+    await tester.pumpWidget(
+      buildEmergencyGridTestApp(
+        userInformation: UserInformation(
+          age: '18-30',
+          location: 'US',
+          service: FakePersistentMemoryService(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Elem עלם'), findsNothing);
+  });
+
+  testWidgets('Elem support opens WhatsApp and website actions', (
+    tester,
+  ) async {
+    final originalPlatform = UrlLauncherPlatform.instance;
+    final fakePlatform = FakeUrlLauncherPlatform();
+    UrlLauncherPlatform.instance = fakePlatform;
+    addTearDown(() {
+      UrlLauncherPlatform.instance = originalPlatform;
+    });
+
+    await tester.pumpWidget(
+      buildEmergencyGridTestApp(
+        userInformation: UserInformation(
+          age: '18-',
+          location: 'US',
+          service: FakePersistentMemoryService(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Elem עלם'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.chat).last);
+    await tester.pumpAndSettle();
+    expect(fakePlatform.lastLaunchedUrl, 'https://wa.me/972546786776');
+
+    await tester.tap(find.byIcon(Icons.language));
+    await tester.pumpAndSettle();
+    expect(fakePlatform.lastLaunchedUrl, 'https://yelem.org.il/');
+  });
+
   test('Emergency numbers match SOS reference data for AU/US/UK/EU', () {
     final usa = countries['usa'];
     final uk = countries['uk'];


### PR DESCRIPTION
# User description
## Summary

- Add the `Elem עלם` support option to the SOS resources for users whose age setting is `18-`.
- Configure the requested WhatsApp contact and Elem website actions.
- Add regression coverage for visibility, adult exclusion, and both links.

## Why

Issue #285 asks for an additional SOS support option for teenage users. Users aged 18 and older must not see this resource.

## Root cause

The SOS data had no Elem resource and the SOS grid had no age-aware supplemental-resource handling.

## Validation

- `flutter test test/emergency_whatsapp_test.dart` — all 20 tests passed.
- `flutter analyze lib/EmergencyNumbers.dart lib/util/Phone/EmergencyPhones.dart test/emergency_whatsapp_test.dart` — no issues found.

Closes #285

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
EmergencyPhonesGrid_build_("EmergencyPhonesGrid.build"):::modified
elemSupportOption_("elemSupportOption"):::added
EmergencyPhonesGrid_build_ -- "Adds Elem support entry for users aged 18-." --> elemSupportOption_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Add the <code>Elem עלם</code> SOS support option and make <code>EmergencyPhonesGrid</code> show it only for users whose age is <code>18-</code>. Extend <code>elemSupportOption</code> with WhatsApp and website actions and cover the new visibility and launch behavior in tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/294?tool=ast&topic=Age+gating>Age gating</a>
        </td><td>Update <code>EmergencyPhonesGrid</code> to append <code>elemSupportOption</code> only for <code>18-</code> users and keep adults from seeing it.<details><summary>Modified files (2)</summary><ul><li>lib/util/Phone/EmergencyPhones.dart</li>
<li>test/emergency_whatsapp_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>test(sos): assert comp...</td><td>July 20, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Implement UX gaps reme...</td><td>June 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/294?tool=ast&topic=Elem+contact>Elem contact</a>
        </td><td>Add the <code>elemSupportOption</code> resource with its WhatsApp and website contact details for teen support.<details><summary>Modified files (2)</summary><ul><li>lib/EmergencyNumbers.dart</li>
<li>test/emergency_whatsapp_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>test(sos): assert comp...</td><td>July 20, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Implement UX gaps reme...</td><td>June 07, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/294?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>