### PR TITLE
[Enhancement LP 1.0] Add SOS location sharing

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
       <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <!-- As per the documentation of flutter local notifications

--- a/docs/adr/ADR-009-sos-location-sharing-dependency.md
+++ b/docs/adr/ADR-009-sos-location-sharing-dependency.md
@@ -1,0 +1,52 @@
+# ADR-009: Approve Foreground SOS Location Dependency
+
+- **Status**: accepted
+- **Date**: 2026-07-31
+- **Deciders**: Lubac (repository collaborator)
+- **Tags**: sos, location, privacy, dependency
+
+## Context
+
+Issue #217 adds a one-time SOS action that appends the user's current
+location to an existing help message before opening the native share sheet.
+The app has no existing current-position abstraction: a repository search
+found only the new `PhonePage` call site, and the existing sharing service is
+responsible only for presenting text to the system share sheet.
+
+Location permissions, GPS availability, and platform implementations are
+volatile concerns. They remain local to the SOS page, while the stable shared
+text-sharing behavior remains in `FileService`. Creating a new application
+abstraction for this single current-position use case would add an unsupported
+boundary without an identified second consumer.
+
+## Decision
+
+The repository collaborator explicitly approves adding the direct dependency
+`geolocator: ^14.0.2` for Issue #217.
+
+- Use it only for an Android/iOS foreground request for one current position.
+- Request only when-in-use permission, obtain a bounded high-accuracy snapshot,
+  and then hand the resulting map link to the existing native share flow.
+- Do not enable background location, continuous location streams, location
+  history, automatic recipient targeting, or tracking of a user's movement.
+- Web and desktop remain text-only SOS fallbacks and must not invoke location
+  access.
+- Retain `^14.0.2` as the currently resolved, validated baseline to avoid
+  unrelated dependency churn. Moving to a later version requires a separately
+  reviewed dependency update.
+
+## Consequences
+
+- The SOS page owns permission and device-location failure handling, keeping
+  volatile GPS behavior out of the shared sharing service.
+- The dependency is deliberately limited to one foreground-only product need;
+  any background, live-tracking, or additional current-position consumer
+  requires a new decision record.
+- The explicit approval and version rationale satisfy the repository rule that
+  new dependencies require human sign-off.
+
+## Links
+
+- Issue #217 — SOS current-location sharing
+- `lib/pages/phone.dart` — sole production location consumer
+- `pubspec.yaml` — approved direct dependency declaration

--- a/integration_test/custom_categories_e2e_test.dart
+++ b/integration_test/custom_categories_e2e_test.dart
@@ -37,7 +37,7 @@ class _NoopFileService implements FileService {
       String textDirection) async {}
 
   @override
-  Future<void> shareTextOnly(String message) async {}
+  Future<bool> shareTextOnly(String message) async => true;
 }
 
 class _NoopLogger implements IncidentLoggerService {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -41,10 +41,13 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
     if target.name == 'geolocator_apple'
       target.build_configurations.each do |config|
-        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
-          '$(inherited)',
-          'BYPASS_PERMISSION_LOCATION_ALWAYS=1',
-        ]
+        definitions = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS']
+        definitions = ['$(inherited)'] if definitions.nil?
+        definitions = definitions.split(/\s+/) if definitions.is_a?(String)
+        unless definitions.include?('BYPASS_PERMISSION_LOCATION_ALWAYS=1')
+          definitions << 'BYPASS_PERMISSION_LOCATION_ALWAYS=1'
+        end
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = definitions
       end
     end
   end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -39,5 +39,13 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    if target.name == 'geolocator_apple'
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+          '$(inherited)',
+          'BYPASS_PERMISSION_LOCATION_ALWAYS=1',
+        ]
+      end
+    end
   end
 end

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -18,6 +18,8 @@
 	<string>Living Positively accesses your camera only when you choose to take a photo to add to your Feel Good collection.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Living Positively accesses your contacts only when you choose a person to add to your personal emergency contacts list. The selected name and phone number are used to show and call that emergency contact.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Living Positively accesses your location only when you choose to share your current location in an SOS message.</string>
 	<key>CFBundleName</key>
 	<string>mezilon</string>
 	<key>CFBundlePackageType</key>

--- a/lib/file_service.dart
+++ b/lib/file_service.dart
@@ -29,7 +29,7 @@ abstract class FileService {
       Map<String, String> texts,
       ShareFileType saveFormat,
       String textDirection);
-  Future<void> shareTextOnly(String message);
+  Future<bool> shareTextOnly(String message);
 }
 
 class FileServiceImpl implements FileService {
@@ -325,11 +325,16 @@ class FileServiceImpl implements FileService {
   }
 
   @override
-  Future<void> shareTextOnly(String message) async {
+  Future<bool> shareTextOnly(String message) async {
     try {
-      await SharePlus.instance.share(ShareParams(text: message));
+      final result =
+          await SharePlus.instance.share(ShareParams(text: message));
+      if (result.status != ShareResultStatus.success) {
+        return false;
+      }
       AnalyticsService mixPanelService = GetIt.instance<AnalyticsService>();
       mixPanelService.trackEvent("Text shared");
+      return true;
     } catch (error, stackTrace) {
       IncidentLoggerService loggerService =
           GetIt.instance<IncidentLoggerService>();
@@ -337,6 +342,7 @@ class FileServiceImpl implements FileService {
         error,
         stackTrace: stackTrace,
       );
+      return false;
     }
   }
 }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -385,6 +385,11 @@
       }
     }
   },
+  "sosShareLocation": "مشاركة الموقع",
+  "sosShareLocationTooltip": "مشاركة موقعك الحالي",
+  "sosShareLocationMessage": "أنا هنا وأحتاج إلى مساعدتك.",
+  "sosShareLocationUnavailable": "تعذّر مشاركة موقعك. ستتم مشاركة رسالة طلب المساعدة بدون الموقع.",
+  "sosShareLocationShareFailed": "تعذّر مشاركة رسالة طلب المساعدة الخاصة بك. يُرجى المحاولة مرة أخرى.",
   "menuTooltip": "القائمة",
   "addItemTooltip": "إضافة",
   "downloadPlanTooltip": "تنزيل الخطة",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -480,6 +480,10 @@
   "@sosShareLocationUnavailable": {
     "description": "Notice shown when SOS location sharing falls back to a text-only help message."
   },
+  "sosShareLocationShareFailed": "Your SOS help message could not be shared. Please try again.",
+  "@sosShareLocationShareFailed": {
+    "description": "Notice shown when the SOS help message cannot be shared through the native share sheet."
+  },
   "phonePageTitle": "{gender,select,male{You are not alone! If you are in distress right now, please reach out to one of the contacts listed here} female{You are not alone! If you are in distress right now, please reach out to one of the contacts listed here} other{You are not alone! If you are in distress right now, please reach out to one of the contacts listed here}}",
   "@phonePageTitle": {
     "description": ""

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -464,6 +464,22 @@
   "@emergencyNumbers": {
     "description": ""
   },
+  "sosShareLocation": "Share Location",
+  "@sosShareLocation": {
+    "description": "The SOS action that shares the user's current location."
+  },
+  "sosShareLocationTooltip": "Share your current location",
+  "@sosShareLocationTooltip": {
+    "description": "Accessibility label for the SOS location-share action."
+  },
+  "sosShareLocationMessage": "I am here and I need your help.",
+  "@sosShareLocationMessage": {
+    "description": "The SOS help message shared with an optional current-location map link."
+  },
+  "sosShareLocationUnavailable": "Your location could not be shared. Your help message will be shared without it.",
+  "@sosShareLocationUnavailable": {
+    "description": "Notice shown when SOS location sharing falls back to a text-only help message."
+  },
   "phonePageTitle": "{gender,select,male{You are not alone! If you are in distress right now, please reach out to one of the contacts listed here} female{You are not alone! If you are in distress right now, please reach out to one of the contacts listed here} other{You are not alone! If you are in distress right now, please reach out to one of the contacts listed here}}",
   "@phonePageTitle": {
     "description": ""

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -140,6 +140,22 @@
      "dialButton": "{gender,select,male{חיוג} female{חיוג} other{חיוג}}",
      "yourContacts": "{gender,select,male{אנשי הקשר שלך} female{אנשי הקשר שלך} other{אנשי הקשר שלך}}",
      "emergencyNumbers": "{gender,select,male{מספרי חירום} female{מספרי חירום} other{מספרי חירום}}",
+     "sosShareLocation": "שיתוף במיקום",
+     "@sosShareLocation": {
+       "description": "הפעולה לשיתוף המיקום הנוכחי בדף החירום."
+     },
+     "sosShareLocationTooltip": "שיתוף המיקום הנוכחי שלך",
+     "@sosShareLocationTooltip": {
+       "description": "תווית נגישות לפעולת שיתוף המיקום בדף החירום."
+     },
+     "sosShareLocationMessage": "אני כאן ויש לי צורך בעזרתך",
+     "@sosShareLocationMessage": {
+       "description": "הודעת העזרה שנשלחת יחד עם קישור למיקום הנוכחי כשזמין."
+     },
+     "sosShareLocationUnavailable": "לא ניתן לשתף את מיקומך. הודעת העזרה תישלח ללא המיקום.",
+     "@sosShareLocationUnavailable": {
+       "description": "הודעה המוצגת כששיתוף המיקום עובר להודעת עזרה ללא מיקום."
+     },
      "whatsApp": "ווצאפ",
       "link": "קישור לאתר",
       "showMoreButton": "{gender,select,male{להציג עוד} female{להציג עוד} other{להציג עוד}}",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -156,6 +156,10 @@
      "@sosShareLocationUnavailable": {
        "description": "הודעה המוצגת כששיתוף המיקום עובר להודעת עזרה ללא מיקום."
      },
+     "sosShareLocationShareFailed": "לא ניתן היה לשתף את הודעת העזרה שלך. נסו שוב.",
+     "@sosShareLocationShareFailed": {
+       "description": "הודעה המוצגת כשלא ניתן לשתף את הודעת העזרה דרך גיליון השיתוף של המכשיר."
+     },
      "whatsApp": "ווצאפ",
       "link": "קישור לאתר",
       "showMoreButton": "{gender,select,male{להציג עוד} female{להציג עוד} other{להציג עוד}}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -832,6 +832,12 @@ abstract class AppLocalizations {
   /// **'Your location could not be shared. Your help message will be shared without it.'**
   String get sosShareLocationUnavailable;
 
+  /// Notice shown when the SOS help message cannot be shared through the native share sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Your SOS help message could not be shared. Please try again.'**
+  String get sosShareLocationShareFailed;
+
   ///
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -808,6 +808,30 @@ abstract class AppLocalizations {
   /// **'{gender,select,male{Emergency Numbers} female{Emergency Numbers} other{Emergency Numbers}}'**
   String emergencyNumbers(String gender);
 
+  /// The SOS action that shares the user's current location.
+  ///
+  /// In en, this message translates to:
+  /// **'Share Location'**
+  String get sosShareLocation;
+
+  /// Accessibility label for the SOS location-share action.
+  ///
+  /// In en, this message translates to:
+  /// **'Share your current location'**
+  String get sosShareLocationTooltip;
+
+  /// The SOS help message shared with an optional current-location map link.
+  ///
+  /// In en, this message translates to:
+  /// **'I am here and I need your help.'**
+  String get sosShareLocationMessage;
+
+  /// Notice shown when SOS location sharing falls back to a text-only help message.
+  ///
+  /// In en, this message translates to:
+  /// **'Your location could not be shared. Your help message will be shared without it.'**
+  String get sosShareLocationUnavailable;
+
   ///
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1106,21 +1106,21 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get sosShareLocation => 'Share Location';
+  String get sosShareLocation => 'مشاركة الموقع';
 
   @override
-  String get sosShareLocationTooltip => 'Share your current location';
+  String get sosShareLocationTooltip => 'مشاركة موقعك الحالي';
 
   @override
-  String get sosShareLocationMessage => 'I am here and I need your help.';
+  String get sosShareLocationMessage => 'أنا هنا وأحتاج إلى مساعدتك.';
 
   @override
   String get sosShareLocationUnavailable =>
-      'Your location could not be shared. Your help message will be shared without it.';
+      'تعذّر مشاركة موقعك. ستتم مشاركة رسالة طلب المساعدة بدون الموقع.';
 
   @override
   String get sosShareLocationShareFailed =>
-      'Your SOS help message could not be shared. Please try again.';
+      'تعذّر مشاركة رسالة طلب المساعدة الخاصة بك. يُرجى المحاولة مرة أخرى.';
 
   @override
   String phonePageTitle(String gender) {

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1106,6 +1106,19 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get sosShareLocation => 'Share Location';
+
+  @override
+  String get sosShareLocationTooltip => 'Share your current location';
+
+  @override
+  String get sosShareLocationMessage => 'I am here and I need your help.';
+
+  @override
+  String get sosShareLocationUnavailable =>
+      'Your location could not be shared. Your help message will be shared without it.';
+
+  @override
   String phonePageTitle(String gender) {
     String _temp0 = intl.Intl.selectLogic(gender, {
       'male':

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1119,6 +1119,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'Your location could not be shared. Your help message will be shared without it.';
 
   @override
+  String get sosShareLocationShareFailed =>
+      'Your SOS help message could not be shared. Please try again.';
+
+  @override
   String phonePageTitle(String gender) {
     String _temp0 = intl.Intl.selectLogic(gender, {
       'male':

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1134,6 +1134,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Your location could not be shared. Your help message will be shared without it.';
 
   @override
+  String get sosShareLocationShareFailed =>
+      'Your SOS help message could not be shared. Please try again.';
+
+  @override
   String phonePageTitle(String gender) {
     String _temp0 = intl.Intl.selectLogic(gender, {
       'male':

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1121,6 +1121,19 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get sosShareLocation => 'Share Location';
+
+  @override
+  String get sosShareLocationTooltip => 'Share your current location';
+
+  @override
+  String get sosShareLocationMessage => 'I am here and I need your help.';
+
+  @override
+  String get sosShareLocationUnavailable =>
+      'Your location could not be shared. Your help message will be shared without it.';
+
+  @override
   String phonePageTitle(String gender) {
     String _temp0 = intl.Intl.selectLogic(gender, {
       'male':

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1113,6 +1113,10 @@ class AppLocalizationsHe extends AppLocalizations {
       'לא ניתן לשתף את מיקומך. הודעת העזרה תישלח ללא המיקום.';
 
   @override
+  String get sosShareLocationShareFailed =>
+      'לא ניתן היה לשתף את הודעת העזרה שלך. נסו שוב.';
+
+  @override
   String phonePageTitle(String gender) {
     String _temp0 = intl.Intl.selectLogic(gender, {
       'male': 'אתה לא לבד! אם אתה עכשיו במצוקה נא פנה לאחד הגורמים הרשומים פה',

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1100,6 +1100,19 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get sosShareLocation => 'שיתוף במיקום';
+
+  @override
+  String get sosShareLocationTooltip => 'שיתוף המיקום הנוכחי שלך';
+
+  @override
+  String get sosShareLocationMessage => 'אני כאן ויש לי צורך בעזרתך';
+
+  @override
+  String get sosShareLocationUnavailable =>
+      'לא ניתן לשתף את מיקומך. הודעת העזרה תישלח ללא המיקום.';
+
+  @override
   String phonePageTitle(String gender) {
     String _temp0 = intl.Intl.selectLogic(gender, {
       'male': 'אתה לא לבד! אם אתה עכשיו במצוקה נא פנה לאחד הגורמים הרשומים פה',

--- a/lib/pages/phone.dart
+++ b/lib/pages/phone.dart
@@ -42,6 +42,7 @@ class _PhonePageState extends LPExtendedState<PhonePage> {
     final fileService = GetIt.instance<FileService>();
     final helpMessage = appLocale.sosShareLocationMessage;
     final unavailableMessage = appLocale.sosShareLocationUnavailable;
+    final shareErrorMessage = appLocale.asyncErrorMessage;
     var messageToShare = helpMessage;
     var locationUnavailable = !_supportsLocationSharing;
 
@@ -86,6 +87,11 @@ class _PhonePageState extends LPExtendedState<PhonePage> {
 
     try {
       await fileService.shareTextOnly(messageToShare);
+    } catch (_) {
+      if (mounted) {
+        messenger?.hideCurrentSnackBar();
+        messenger?.showSnackBar(SnackBar(content: Text(shareErrorMessage)));
+      }
     } finally {
       if (mounted) {
         setState(() {

--- a/lib/pages/phone.dart
+++ b/lib/pages/phone.dart
@@ -42,7 +42,7 @@ class _PhonePageState extends LPExtendedState<PhonePage> {
     final fileService = GetIt.instance<FileService>();
     final helpMessage = appLocale.sosShareLocationMessage;
     final unavailableMessage = appLocale.sosShareLocationUnavailable;
-    final shareErrorMessage = appLocale.asyncErrorMessage;
+    final shareFailedMessage = appLocale.sosShareLocationShareFailed;
     var messageToShare = helpMessage;
     var locationUnavailable = !_supportsLocationSharing;
 
@@ -86,11 +86,15 @@ class _PhonePageState extends LPExtendedState<PhonePage> {
     }
 
     try {
-      await fileService.shareTextOnly(messageToShare);
+      final shareSucceeded = await fileService.shareTextOnly(messageToShare);
+      if (!shareSucceeded && mounted) {
+        messenger?.hideCurrentSnackBar();
+        messenger?.showSnackBar(SnackBar(content: Text(shareFailedMessage)));
+      }
     } catch (_) {
       if (mounted) {
         messenger?.hideCurrentSnackBar();
-        messenger?.showSnackBar(SnackBar(content: Text(shareErrorMessage)));
+        messenger?.showSnackBar(SnackBar(content: Text(shareFailedMessage)));
       }
     } finally {
       if (mounted) {

--- a/lib/pages/phone.dart
+++ b/lib/pages/phone.dart
@@ -61,8 +61,7 @@ class _PhonePageState extends LPExtendedState<PhonePage> {
             permission = await Geolocator.requestPermission();
           }
 
-          if (permission == LocationPermission.whileInUse ||
-              permission == LocationPermission.always) {
+          if (permission == LocationPermission.whileInUse) {
             final position = await Geolocator.getCurrentPosition(
               locationSettings: const LocationSettings(
                 accuracy: LocationAccuracy.high,

--- a/lib/pages/phone.dart
+++ b/lib/pages/phone.dart
@@ -1,4 +1,9 @@
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mazilon/file_service.dart';
 import 'package:mazilon/form/phonePageform.dart';
 import 'package:mazilon/util/LP_extended_state.dart';
 import 'package:mazilon/util/Phone/phoneTextAndIcon.dart';
@@ -21,6 +26,74 @@ class _PhonePageState extends LPExtendedState<PhonePage> {
   String mainTitle = '';
   String contactsTitle = '';
   String emergencyNumbersTitle = '';
+  bool _isSharingLocation = false;
+
+  bool get _supportsLocationSharing =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
+  Future<void> _shareCurrentLocation() async {
+    if (_isSharingLocation) {
+      return;
+    }
+
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    final fileService = GetIt.instance<FileService>();
+    final helpMessage = appLocale.sosShareLocationMessage;
+    final unavailableMessage = appLocale.sosShareLocationUnavailable;
+    var messageToShare = helpMessage;
+    var locationUnavailable = !_supportsLocationSharing;
+
+    setState(() {
+      _isSharingLocation = true;
+    });
+
+    try {
+      if (!locationUnavailable) {
+        final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+        if (!serviceEnabled) {
+          locationUnavailable = true;
+        } else {
+          var permission = await Geolocator.checkPermission();
+          if (permission == LocationPermission.denied) {
+            permission = await Geolocator.requestPermission();
+          }
+
+          if (permission == LocationPermission.whileInUse ||
+              permission == LocationPermission.always) {
+            final position = await Geolocator.getCurrentPosition(
+              locationSettings: const LocationSettings(
+                accuracy: LocationAccuracy.high,
+                timeLimit: Duration(seconds: 15),
+              ),
+            );
+            messageToShare =
+                '$helpMessage\nhttps://www.google.com/maps/search/?api=1&query=${position.latitude},${position.longitude}';
+          } else {
+            locationUnavailable = true;
+          }
+        }
+      }
+    } catch (_) {
+      locationUnavailable = true;
+    }
+
+    if (locationUnavailable && mounted) {
+      messenger?.hideCurrentSnackBar();
+      messenger?.showSnackBar(SnackBar(content: Text(unavailableMessage)));
+    }
+
+    try {
+      await fileService.shareTextOnly(messageToShare);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSharingLocation = false;
+        });
+      }
+    }
+  }
 
   void _openContactsEditor() {
     Navigator.of(context).push(
@@ -161,6 +234,36 @@ class _PhonePageState extends LPExtendedState<PhonePage> {
                         ),
                       );
                     },
+                  ),
+                  const SizedBox(height: 10.0),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 30.0),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Flexible(
+                          child: myText(
+                            appLocale.sosShareLocation,
+                            TextStyle(
+                              fontWeight: FontWeight.normal,
+                              fontSize: 20.sp,
+                            ),
+                            null,
+                          ),
+                        ),
+                        const SizedBox(width: 5.0),
+                        KeyedSubtree(
+                          key: const Key('phonePageShareLocationButton'),
+                          child: circularActionButton(
+                            context,
+                            tooltip: appLocale.sosShareLocationTooltip,
+                            icon: Icons.location_on,
+                            onTap: _shareCurrentLocation,
+                          ),
+                        ),
+                        const SizedBox(width: 10.0),
+                      ],
+                    ),
                   ),
                   const SizedBox(height: 10.0),
                   Align(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -703,6 +703,70 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  geoclue:
+    dependency: transitive
+    description:
+      name: geoclue
+      sha256: c2a998c77474fc57aa00c6baa2928e58f4b267649057a1c76738656e9dbd2a7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
+  geolocator:
+    dependency: "direct main"
+    description:
+      name: geolocator
+      sha256: "79939537046c9025be47ec645f35c8090ecadb6fe98eba146a0d25e8c1357516"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.0.2"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: "86ea1654e4f61ff51466848e91c116b422d6010ea269fda0fbe1af7e9e742ce1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: "853803d6bb1713c094e935b4a5ae5f19c0308acf81da13fa9ff84fb4c70c0b73"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.14"
+  geolocator_linux:
+    dependency: transitive
+    description:
+      name: geolocator_linux
+      sha256: d64112a205931926f4363bb6bd48f14cb38e7326833041d170615586cd143797
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: cdb082e4f048b69da244117b7914cc60d2a8897546ffaa4f2529c786ded7aee2
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.8"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: "19e485a0f8d6a88abcf9c53cba3a4105e14b7435ed8ac1c108c067b938fe8429"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.4"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: "175435404d20278ffd220de83c2ca293b73db95eafbdc8131fe8609be1421eb6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
   get_it:
     dependency: "direct main"
     description:
@@ -767,6 +831,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gsettings:
+    dependency: transitive
+    description:
+      name: gsettings
+      sha256: "1b0ce661f5436d2db1e51f3c4295a49849f03d304003a7ba177d01e3a858249c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   url_launcher: 6.3.2
 
   permission_handler: ^12.0.1
+  geolocator: ^14.0.2
   flutter_local_notifications: ^21.0.0
   pdf: ^3.12.0
   path_provider: ^2.1.5

--- a/test/MenuTest/Feelgood/feelGood_test.mocks.dart
+++ b/test/MenuTest/Feelgood/feelGood_test.mocks.dart
@@ -169,14 +169,14 @@ class MockFileService extends _i1.Mock implements _i6.FileService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<void> shareTextOnly(String? message) => (super.noSuchMethod(
+  _i7.Future<bool> shareTextOnly(String? message) => (super.noSuchMethod(
         Invocation.method(
           #shareTextOnly,
           [message],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i7.Future<bool>.value(false),
+        returnValueForMissingStub: _i7.Future<bool>.value(false),
+      ) as _i7.Future<bool>);
 }
 
 /// A class which mocks [ImagePickerService].

--- a/test/MenuTest/Wellness/wellnessTools_test.mocks.dart
+++ b/test/MenuTest/Wellness/wellnessTools_test.mocks.dart
@@ -126,14 +126,14 @@ class MockFileService extends _i1.Mock implements _i6.FileService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<void> shareTextOnly(String? message) => (super.noSuchMethod(
+  _i7.Future<bool> shareTextOnly(String? message) => (super.noSuchMethod(
         Invocation.method(
           #shareTextOnly,
           [message],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i7.Future<bool>.value(false),
+        returnValueForMissingStub: _i7.Future<bool>.value(false),
+      ) as _i7.Future<bool>);
 }
 
 /// A class which mocks [VideoPlayerPageFactory].

--- a/test/MenuTest/reminder_visibility_test.dart
+++ b/test/MenuTest/reminder_visibility_test.dart
@@ -82,7 +82,7 @@ class _FakeFileService implements FileService {
   }
 
   @override
-  Future<void> shareTextOnly(String message) async {}
+  Future<bool> shareTextOnly(String message) async => true;
 }
 
 class _FakeUrlLauncherPlatform extends UrlLauncherPlatform {

--- a/test/MenuTest/shareAndDownload/share_and_download_test.mocks.dart
+++ b/test/MenuTest/shareAndDownload/share_and_download_test.mocks.dart
@@ -127,14 +127,14 @@ class MockFileService extends _i1.Mock implements _i6.FileService {
       ) as _i7.Future<String?>);
 
   @override
-  _i7.Future<void> shareTextOnly(String? message) => (super.noSuchMethod(
+  _i7.Future<bool> shareTextOnly(String? message) => (super.noSuchMethod(
         Invocation.method(
           #shareTextOnly,
           [message],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i7.Future<bool>.value(false),
+        returnValueForMissingStub: _i7.Future<bool>.value(false),
+      ) as _i7.Future<bool>);
 }
 
 /// A class which mocks [UserInformation].

--- a/test/a11y/phase_b_semantics_test.dart
+++ b/test/a11y/phase_b_semantics_test.dart
@@ -106,7 +106,7 @@ class _StubFileService implements FileService {
     String textDirection,
   ) async => null;
   @override
-  Future<void> shareTextOnly(String message) async {}
+  Future<bool> shareTextOnly(String message) async => true;
 }
 
 Widget _wrap(

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -1259,6 +1259,19 @@ void main() {
     },
   );
 
+  testWidgets('PhonePage treats always location permission as unavailable', (
+    tester,
+  ) async {
+    final geolocator = FakeGeolocatorPlatform(
+      permission: LocationPermission.always,
+    );
+
+    await _expectTextOnlyLocationFallback(tester, geolocator);
+
+    expect(geolocator.requestPermissionCalls, 0);
+    expect(geolocator.currentPositionCalls, 0);
+  });
+
   testWidgets(
     'PhonePage shares help text when location availability cannot be determined',
     (tester) async {

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -71,7 +71,12 @@ class FakeUrlLauncherPlatform extends UrlLauncherPlatform {
 }
 
 class RecordingFileService implements FileService {
+  RecordingFileService({List<String>? callLog, this.failuresRemaining = 0})
+    : callLog = callLog ?? [];
+
+  final List<String> callLog;
   final List<String> sharedMessages = [];
+  int failuresRemaining;
 
   @override
   Future<String?> download(
@@ -94,6 +99,11 @@ class RecordingFileService implements FileService {
 
   @override
   Future<void> shareTextOnly(String message) async {
+    callLog.add('shareTextOnly');
+    if (failuresRemaining > 0) {
+      failuresRemaining--;
+      throw StateError('shareTextOnly failed');
+    }
     sharedMessages.add(message);
   }
 }
@@ -106,8 +116,10 @@ class FakeGeolocatorPlatform extends GeolocatorPlatform {
     this.position,
     this.positionError,
     this.positionCompleter,
-  });
+    List<String>? callLog,
+  }) : callLog = callLog ?? [];
 
+  final List<String> callLog;
   final bool serviceEnabled;
   final LocationPermission permission;
   final LocationPermission? requestedPermission;
@@ -117,25 +129,33 @@ class FakeGeolocatorPlatform extends GeolocatorPlatform {
   int checkPermissionCalls = 0;
   int requestPermissionCalls = 0;
   int currentPositionCalls = 0;
+  int locationServiceEnabledCalls = 0;
   LocationSettings? lastLocationSettings;
 
   @override
   Future<LocationPermission> checkPermission() async {
+    callLog.add('checkPermission');
     checkPermissionCalls++;
     return permission;
   }
 
   @override
   Future<LocationPermission> requestPermission() async {
+    callLog.add('requestPermission');
     requestPermissionCalls++;
     return requestedPermission ?? permission;
   }
 
   @override
-  Future<bool> isLocationServiceEnabled() async => serviceEnabled;
+  Future<bool> isLocationServiceEnabled() async {
+    callLog.add('isLocationServiceEnabled');
+    locationServiceEnabledCalls++;
+    return serviceEnabled;
+  }
 
   @override
   Future<Position> getCurrentPosition({LocationSettings? locationSettings}) {
+    callLog.add('getCurrentPosition');
     currentPositionCalls++;
     lastLocationSettings = locationSettings;
     if (positionCompleter != null) {
@@ -1069,67 +1089,90 @@ void main() {
     },
   );
 
-  testWidgets(
-    'PhonePage shares a high-accuracy current location after personal contacts',
-    (tester) async {
-      final geolocator = FakeGeolocatorPlatform(
-        position: _testPosition(latitude: 31.7683, longitude: 35.2137),
-      );
-      final fileService = RecordingFileService();
-      await _runLocationShareTest(
-        geolocator,
-        fileService,
-        body: () async {
-          final phonePageData = _phonePageDataForLocationShare();
+  for (final platform in <TargetPlatform>[
+    TargetPlatform.android,
+    TargetPlatform.iOS,
+  ]) {
+    testWidgets(
+      'PhonePage shares a high-accuracy current location after personal contacts on $platform',
+      (tester) async {
+        final callLog = <String>[];
+        final geolocator = FakeGeolocatorPlatform(
+          permission: LocationPermission.denied,
+          requestedPermission: LocationPermission.whileInUse,
+          position: _testPosition(latitude: 31.7683, longitude: 35.2137),
+          callLog: callLog,
+        );
+        final fileService = RecordingFileService(callLog: callLog);
+        await _runLocationShareTest(
+          geolocator,
+          fileService,
+          platform: platform,
+          body: () async {
+            final phonePageData = _phonePageDataForLocationShare();
 
-          await tester.pumpWidget(
-            buildPhonePageTestApp(
-              userInformation: UserInformation(
-                gender: 'male',
-                location: 'US',
-                service: FakePersistentMemoryService(),
+            await tester.pumpWidget(
+              buildPhonePageTestApp(
+                userInformation: UserInformation(
+                  gender: 'male',
+                  location: 'US',
+                  service: FakePersistentMemoryService(),
+                ),
+                appInformation: AppInformation(),
+                phonePageData: phonePageData,
               ),
-              appInformation: AppInformation(),
-              phonePageData: phonePageData,
-            ),
-          );
-          await tester.pumpAndSettle();
+            );
+            await tester.pumpAndSettle();
 
-          final contactSection = find.text('Your contacts');
-          final shareLocation = find.text('Share Location');
-          final emergencyNumbers = find.text('Emergency Numbers');
-          expect(contactSection, findsOneWidget);
-          expect(shareLocation, findsOneWidget);
-          expect(emergencyNumbers, findsOneWidget);
-          expect(
-            tester.getTopLeft(shareLocation).dy,
-            greaterThan(tester.getTopLeft(contactSection).dy),
-          );
-          expect(
-            tester.getTopLeft(emergencyNumbers).dy,
-            greaterThan(tester.getTopLeft(shareLocation).dy),
-          );
-          expect(find.byTooltip('Share your current location'), findsOneWidget);
+            final contactSection = find.text('Your contacts');
+            final shareLocation = find.text('Share Location');
+            final emergencyNumbers = find.text('Emergency Numbers');
+            expect(contactSection, findsOneWidget);
+            expect(shareLocation, findsOneWidget);
+            expect(emergencyNumbers, findsOneWidget);
+            expect(
+              tester.getTopLeft(shareLocation).dy,
+              greaterThan(tester.getTopLeft(contactSection).dy),
+            );
+            expect(
+              tester.getTopLeft(emergencyNumbers).dy,
+              greaterThan(tester.getTopLeft(shareLocation).dy),
+            );
+            expect(
+              find.byTooltip('Share your current location'),
+              findsOneWidget,
+            );
 
-          await _tapLocationShare(tester);
+            await _tapLocationShare(tester);
 
-          expect(fileService.sharedMessages, [
-            'I am here and I need your help.\n'
-                'https://www.google.com/maps/search/?api=1&query=31.7683,35.2137',
-          ]);
-          expect(geolocator.currentPositionCalls, 1);
-          expect(
-            geolocator.lastLocationSettings?.accuracy,
-            LocationAccuracy.high,
-          );
-          expect(
-            geolocator.lastLocationSettings?.timeLimit,
-            const Duration(seconds: 15),
-          );
-        },
-      );
-    },
-  );
+            expect(callLog, [
+              'isLocationServiceEnabled',
+              'checkPermission',
+              'requestPermission',
+              'getCurrentPosition',
+              'shareTextOnly',
+            ]);
+            expect(fileService.sharedMessages, [
+              'I am here and I need your help.\n'
+                  'https://www.google.com/maps/search/?api=1&query=31.7683,35.2137',
+            ]);
+            expect(geolocator.locationServiceEnabledCalls, 1);
+            expect(geolocator.checkPermissionCalls, 1);
+            expect(geolocator.requestPermissionCalls, 1);
+            expect(geolocator.currentPositionCalls, 1);
+            expect(
+              geolocator.lastLocationSettings?.accuracy,
+              LocationAccuracy.high,
+            );
+            expect(
+              geolocator.lastLocationSettings?.timeLimit,
+              const Duration(seconds: 15),
+            );
+          },
+        );
+      },
+    );
+  }
 
   testWidgets('PhonePage localizes SOS location sharing in Hebrew', (
     tester,
@@ -1255,9 +1298,63 @@ void main() {
       platform: TargetPlatform.windows,
     );
 
+    expect(geolocator.locationServiceEnabledCalls, 0);
     expect(geolocator.checkPermissionCalls, 0);
+    expect(geolocator.requestPermissionCalls, 0);
     expect(geolocator.currentPositionCalls, 0);
+    expect(geolocator.callLog, isEmpty);
   });
+
+  testWidgets('PhonePage shares help text without GPS on web', (tester) async {
+    final geolocator = FakeGeolocatorPlatform();
+
+    await _expectTextOnlyLocationFallback(tester, geolocator);
+
+    expect(geolocator.locationServiceEnabledCalls, 0);
+    expect(geolocator.checkPermissionCalls, 0);
+    expect(geolocator.requestPermissionCalls, 0);
+    expect(geolocator.currentPositionCalls, 0);
+    expect(geolocator.callLog, isEmpty);
+  }, skip: !kIsWeb);
+
+  testWidgets(
+    'PhonePage shows localized feedback and allows retry when sharing fails',
+    (tester) async {
+      final geolocator = FakeGeolocatorPlatform();
+      final fileService = RecordingFileService(failuresRemaining: 1);
+      await _runLocationShareTest(
+        geolocator,
+        fileService,
+        body: () async {
+          await tester.pumpWidget(
+            buildPhonePageTestApp(
+              userInformation: UserInformation(
+                gender: 'male',
+                location: 'IL',
+                service: FakePersistentMemoryService(),
+              ),
+              appInformation: AppInformation(),
+              phonePageData: _phonePageDataForLocationShare(),
+              locale: const Locale('he'),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await _tapLocationShare(tester);
+
+          expect(tester.takeException(), isNull);
+          expect(find.text('משהו השתבש'), findsOneWidget);
+          expect(fileService.sharedMessages, isEmpty);
+
+          await _tapLocationShare(tester);
+
+          expect(tester.takeException(), isNull);
+          expect(fileService.sharedMessages, hasLength(1));
+          expect(geolocator.currentPositionCalls, 2);
+        },
+      );
+    },
+  );
 
   testWidgets('PhonePage ignores a repeated location-share tap while loading', (
     tester,

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -246,6 +246,7 @@ Future<void> _expectTextOnlyLocationFallback(
   WidgetTester tester,
   FakeGeolocatorPlatform geolocator, {
   TargetPlatform platform = TargetPlatform.android,
+  Locale locale = const Locale('en', 'US'),
 }) async {
   final fileService = RecordingFileService();
   await _runLocationShareTest(
@@ -265,16 +266,20 @@ Future<void> _expectTextOnlyLocationFallback(
           userInformation: userInfo,
           appInformation: AppInformation(),
           phonePageData: phonePageData,
+          locale: locale,
         ),
       );
       await tester.pumpAndSettle();
       await _tapLocationShare(tester);
 
-      expect(fileService.sharedMessages, ['I am here and I need your help.']);
+      final localizations = AppLocalizations.of(
+        tester.element(find.byType(PhonePage)),
+      )!;
+      expect(fileService.sharedMessages, [
+        localizations.sosShareLocationMessage,
+      ]);
       expect(
-        find.text(
-          'Your location could not be shared. Your help message will be shared without it.',
-        ),
+        find.text(localizations.sosShareLocationUnavailable),
         findsOneWidget,
       );
     },
@@ -1231,6 +1236,21 @@ void main() {
     },
   );
 
+  testWidgets('PhonePage localizes SOS location fallback feedback in Arabic', (
+    tester,
+  ) async {
+    final geolocator = FakeGeolocatorPlatform(serviceEnabled: false);
+
+    await _expectTextOnlyLocationFallback(
+      tester,
+      geolocator,
+      locale: const Locale('ar'),
+    );
+
+    expect(geolocator.checkPermissionCalls, 0);
+    expect(geolocator.currentPositionCalls, 0);
+  });
+
   testWidgets('PhonePage shares help text when location permission is denied', (
     tester,
   ) async {
@@ -1340,7 +1360,7 @@ void main() {
   }, skip: !kIsWeb);
 
   testWidgets(
-    'PhonePage shows localized SOS feedback and allows retry when sharing is not confirmed',
+    'PhonePage shows localized Arabic SOS feedback and allows retry when sharing is not confirmed',
     (tester) async {
       final geolocator = FakeGeolocatorPlatform();
       final fileService = RecordingFileService(failedResultsRemaining: 1);
@@ -1357,7 +1377,7 @@ void main() {
               ),
               appInformation: AppInformation(),
               phonePageData: _phonePageDataForLocationShare(),
-              locale: const Locale('he'),
+              locale: const Locale('ar'),
             ),
           );
           await tester.pumpAndSettle();
@@ -1383,6 +1403,46 @@ void main() {
       );
     },
   );
+
+  testWidgets('PhonePage localizes SOS location sharing in Arabic', (
+    tester,
+  ) async {
+    final geolocator = FakeGeolocatorPlatform();
+    final fileService = RecordingFileService();
+    await _runLocationShareTest(
+      geolocator,
+      fileService,
+      body: () async {
+        await tester.pumpWidget(
+          buildPhonePageTestApp(
+            userInformation: UserInformation(
+              gender: 'male',
+              location: 'IL',
+              service: FakePersistentMemoryService(),
+            ),
+            appInformation: AppInformation(),
+            phonePageData: _phonePageDataForLocationShare(),
+            locale: const Locale('ar'),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          Directionality.of(tester.element(find.byType(PhonePage))),
+          TextDirection.rtl,
+        );
+        expect(find.text('مشاركة الموقع'), findsOneWidget);
+        expect(find.byTooltip('مشاركة موقعك الحالي'), findsOneWidget);
+
+        await _tapLocationShare(tester);
+
+        expect(fileService.sharedMessages, [
+          'أنا هنا وأحتاج إلى مساعدتك.\n'
+              'https://www.google.com/maps/search/?api=1&query=31.7683,35.2137',
+        ]);
+      },
+    );
+  });
 
   testWidgets(
     'PhonePage shows localized SOS feedback and allows retry when sharing throws',

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mazilon/EmergencyNumbers.dart';
+import 'package:mazilon/file_service.dart';
 import 'package:mazilon/form/phonePageform.dart';
 import 'package:mazilon/global_enums.dart';
 import 'package:mazilon/l10n/app_localizations.dart';
@@ -64,6 +68,188 @@ class FakeUrlLauncherPlatform extends UrlLauncherPlatform {
     launchedUrls.add(url);
     return true;
   }
+}
+
+class RecordingFileService implements FileService {
+  final List<String> sharedMessages = [];
+
+  @override
+  Future<String?> download(
+    List<dynamic> titles,
+    List<dynamic> subTitles,
+    Map<String, String> texts,
+    ShareFileType saveFormat,
+    String textDirection,
+  ) async => null;
+
+  @override
+  Future<void> share(
+    String message,
+    List<dynamic> titles,
+    List<dynamic> subTitles,
+    Map<String, String> texts,
+    ShareFileType saveFormat,
+    String textDirection,
+  ) async {}
+
+  @override
+  Future<void> shareTextOnly(String message) async {
+    sharedMessages.add(message);
+  }
+}
+
+class FakeGeolocatorPlatform extends GeolocatorPlatform {
+  FakeGeolocatorPlatform({
+    this.serviceEnabled = true,
+    this.permission = LocationPermission.whileInUse,
+    this.requestedPermission,
+    this.position,
+    this.positionError,
+    this.positionCompleter,
+  });
+
+  final bool serviceEnabled;
+  final LocationPermission permission;
+  final LocationPermission? requestedPermission;
+  final Position? position;
+  final Object? positionError;
+  final Completer<Position>? positionCompleter;
+  int checkPermissionCalls = 0;
+  int requestPermissionCalls = 0;
+  int currentPositionCalls = 0;
+  LocationSettings? lastLocationSettings;
+
+  @override
+  Future<LocationPermission> checkPermission() async {
+    checkPermissionCalls++;
+    return permission;
+  }
+
+  @override
+  Future<LocationPermission> requestPermission() async {
+    requestPermissionCalls++;
+    return requestedPermission ?? permission;
+  }
+
+  @override
+  Future<bool> isLocationServiceEnabled() async => serviceEnabled;
+
+  @override
+  Future<Position> getCurrentPosition({LocationSettings? locationSettings}) {
+    currentPositionCalls++;
+    lastLocationSettings = locationSettings;
+    if (positionCompleter != null) {
+      return positionCompleter!.future;
+    }
+    if (positionError != null) {
+      return Future<Position>.error(positionError!);
+    }
+    return Future<Position>.value(position ?? _testPosition());
+  }
+}
+
+Position _testPosition({
+  double latitude = 31.7683,
+  double longitude = 35.2137,
+}) {
+  return Position(
+    latitude: latitude,
+    longitude: longitude,
+    timestamp: DateTime.utc(2026),
+    accuracy: 1,
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    headingAccuracy: 0,
+    speed: 0,
+    speedAccuracy: 0,
+  );
+}
+
+PhonePageData _phonePageDataForLocationShare() {
+  return PhonePageData(
+    key: 'phonePageData',
+    header: 'header',
+    subTitle: 'subTitle',
+    midTitle: 'midTitle',
+    phoneNameTitle: 'phoneNameTitle',
+    phoneNumberTitle: 'phoneNumberTitle',
+    phoneNames: const [],
+    phoneNumbers: const [],
+    savedPhoneNames: const [],
+    savedPhoneNumbers: const [],
+    phoneDescription: const [],
+  );
+}
+
+Future<void> _runLocationShareTest(
+  FakeGeolocatorPlatform geolocator,
+  RecordingFileService fileService, {
+  required Future<void> Function() body,
+  TargetPlatform platform = TargetPlatform.android,
+}) async {
+  final originalGeolocator = GeolocatorPlatform.instance;
+  try {
+    await GetIt.instance.reset();
+    GetIt.instance.registerSingleton<PersistentMemoryService>(
+      FakePersistentMemoryService(),
+    );
+    GetIt.instance.registerSingleton<FileService>(fileService);
+
+    GeolocatorPlatform.instance = geolocator;
+    debugDefaultTargetPlatformOverride = platform;
+    await body();
+  } finally {
+    debugDefaultTargetPlatformOverride = null;
+    GeolocatorPlatform.instance = originalGeolocator;
+    await GetIt.instance.reset();
+  }
+}
+
+Future<void> _tapLocationShare(WidgetTester tester) async {
+  final locationAction = find.byKey(const Key('phonePageShareLocationButton'));
+  await tester.ensureVisible(locationAction);
+  await tester.tap(locationAction, warnIfMissed: false);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _expectTextOnlyLocationFallback(
+  WidgetTester tester,
+  FakeGeolocatorPlatform geolocator, {
+  TargetPlatform platform = TargetPlatform.android,
+}) async {
+  final fileService = RecordingFileService();
+  await _runLocationShareTest(
+    geolocator,
+    fileService,
+    platform: platform,
+    body: () async {
+      final userInfo = UserInformation(
+        gender: 'male',
+        location: 'US',
+        service: FakePersistentMemoryService(),
+      );
+      final phonePageData = _phonePageDataForLocationShare();
+
+      await tester.pumpWidget(
+        buildPhonePageTestApp(
+          userInformation: userInfo,
+          appInformation: AppInformation(),
+          phonePageData: phonePageData,
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _tapLocationShare(tester);
+
+      expect(fileService.sharedMessages, ['I am here and I need your help.']);
+      expect(
+        find.text(
+          'Your location could not be shared. Your help message will be shared without it.',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
 }
 
 Widget buildEmergencyDialogTestApp({
@@ -882,4 +1068,238 @@ void main() {
       expect(fakePlatform.lastLaunchedUrl, 'https://sahar.org.il/');
     },
   );
+
+  testWidgets(
+    'PhonePage shares a high-accuracy current location after personal contacts',
+    (tester) async {
+      final geolocator = FakeGeolocatorPlatform(
+        position: _testPosition(latitude: 31.7683, longitude: 35.2137),
+      );
+      final fileService = RecordingFileService();
+      await _runLocationShareTest(
+        geolocator,
+        fileService,
+        body: () async {
+          final phonePageData = _phonePageDataForLocationShare();
+
+          await tester.pumpWidget(
+            buildPhonePageTestApp(
+              userInformation: UserInformation(
+                gender: 'male',
+                location: 'US',
+                service: FakePersistentMemoryService(),
+              ),
+              appInformation: AppInformation(),
+              phonePageData: phonePageData,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final contactSection = find.text('Your contacts');
+          final shareLocation = find.text('Share Location');
+          final emergencyNumbers = find.text('Emergency Numbers');
+          expect(contactSection, findsOneWidget);
+          expect(shareLocation, findsOneWidget);
+          expect(emergencyNumbers, findsOneWidget);
+          expect(
+            tester.getTopLeft(shareLocation).dy,
+            greaterThan(tester.getTopLeft(contactSection).dy),
+          );
+          expect(
+            tester.getTopLeft(emergencyNumbers).dy,
+            greaterThan(tester.getTopLeft(shareLocation).dy),
+          );
+          expect(find.byTooltip('Share your current location'), findsOneWidget);
+
+          await _tapLocationShare(tester);
+
+          expect(fileService.sharedMessages, [
+            'I am here and I need your help.\n'
+                'https://www.google.com/maps/search/?api=1&query=31.7683,35.2137',
+          ]);
+          expect(geolocator.currentPositionCalls, 1);
+          expect(
+            geolocator.lastLocationSettings?.accuracy,
+            LocationAccuracy.high,
+          );
+          expect(
+            geolocator.lastLocationSettings?.timeLimit,
+            const Duration(seconds: 15),
+          );
+        },
+      );
+    },
+  );
+
+  testWidgets('PhonePage localizes SOS location sharing in Hebrew', (
+    tester,
+  ) async {
+    final geolocator = FakeGeolocatorPlatform();
+    final fileService = RecordingFileService();
+    await _runLocationShareTest(
+      geolocator,
+      fileService,
+      body: () async {
+        await tester.pumpWidget(
+          buildPhonePageTestApp(
+            userInformation: UserInformation(
+              gender: 'male',
+              location: 'IL',
+              service: FakePersistentMemoryService(),
+            ),
+            appInformation: AppInformation(),
+            phonePageData: _phonePageDataForLocationShare(),
+            locale: const Locale('he'),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('שיתוף במיקום'), findsOneWidget);
+        expect(find.byTooltip('שיתוף המיקום הנוכחי שלך'), findsOneWidget);
+
+        await _tapLocationShare(tester);
+
+        expect(fileService.sharedMessages, [
+          'אני כאן ויש לי צורך בעזרתך\n'
+              'https://www.google.com/maps/search/?api=1&query=31.7683,35.2137',
+        ]);
+      },
+    );
+  });
+
+  testWidgets(
+    'PhonePage shares help text when location services are disabled',
+    (tester) async {
+      final geolocator = FakeGeolocatorPlatform(serviceEnabled: false);
+
+      await _expectTextOnlyLocationFallback(tester, geolocator);
+
+      expect(geolocator.checkPermissionCalls, 0);
+      expect(geolocator.currentPositionCalls, 0);
+    },
+  );
+
+  testWidgets('PhonePage shares help text when location permission is denied', (
+    tester,
+  ) async {
+    final geolocator = FakeGeolocatorPlatform(
+      permission: LocationPermission.denied,
+      requestedPermission: LocationPermission.denied,
+    );
+
+    await _expectTextOnlyLocationFallback(tester, geolocator);
+
+    expect(geolocator.requestPermissionCalls, 1);
+    expect(geolocator.currentPositionCalls, 0);
+  });
+
+  testWidgets(
+    'PhonePage shares help text when location permission is permanently denied',
+    (tester) async {
+      final geolocator = FakeGeolocatorPlatform(
+        permission: LocationPermission.deniedForever,
+      );
+
+      await _expectTextOnlyLocationFallback(tester, geolocator);
+
+      expect(geolocator.requestPermissionCalls, 0);
+      expect(geolocator.currentPositionCalls, 0);
+    },
+  );
+
+  testWidgets(
+    'PhonePage shares help text when location availability cannot be determined',
+    (tester) async {
+      final geolocator = FakeGeolocatorPlatform(
+        permission: LocationPermission.unableToDetermine,
+      );
+
+      await _expectTextOnlyLocationFallback(tester, geolocator);
+
+      expect(geolocator.currentPositionCalls, 0);
+    },
+  );
+
+  testWidgets('PhonePage shares help text when location lookup times out', (
+    tester,
+  ) async {
+    final geolocator = FakeGeolocatorPlatform(
+      positionError: TimeoutException('location lookup timed out'),
+    );
+
+    await _expectTextOnlyLocationFallback(tester, geolocator);
+
+    expect(geolocator.currentPositionCalls, 1);
+  });
+
+  testWidgets('PhonePage shares help text when location lookup throws', (
+    tester,
+  ) async {
+    final geolocator = FakeGeolocatorPlatform(
+      positionError: StateError('location lookup failed'),
+    );
+
+    await _expectTextOnlyLocationFallback(tester, geolocator);
+
+    expect(geolocator.currentPositionCalls, 1);
+  });
+
+  testWidgets('PhonePage shares help text without GPS on desktop', (
+    tester,
+  ) async {
+    final geolocator = FakeGeolocatorPlatform();
+
+    await _expectTextOnlyLocationFallback(
+      tester,
+      geolocator,
+      platform: TargetPlatform.windows,
+    );
+
+    expect(geolocator.checkPermissionCalls, 0);
+    expect(geolocator.currentPositionCalls, 0);
+  });
+
+  testWidgets('PhonePage ignores a repeated location-share tap while loading', (
+    tester,
+  ) async {
+    final positionCompleter = Completer<Position>();
+    final geolocator = FakeGeolocatorPlatform(
+      positionCompleter: positionCompleter,
+    );
+    final fileService = RecordingFileService();
+    await _runLocationShareTest(
+      geolocator,
+      fileService,
+      body: () async {
+        await tester.pumpWidget(
+          buildPhonePageTestApp(
+            userInformation: UserInformation(
+              gender: 'male',
+              location: 'US',
+              service: FakePersistentMemoryService(),
+            ),
+            appInformation: AppInformation(),
+            phonePageData: _phonePageDataForLocationShare(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final locationAction = find.byKey(
+          const Key('phonePageShareLocationButton'),
+        );
+        await tester.ensureVisible(locationAction);
+        await tester.tap(locationAction, warnIfMissed: false);
+        await tester.pump();
+        await tester.tap(locationAction, warnIfMissed: false);
+        await tester.pump();
+
+        expect(geolocator.currentPositionCalls, 1);
+
+        positionCompleter.complete(_testPosition());
+        await tester.pumpAndSettle();
+
+        expect(fileService.sharedMessages, hasLength(1));
+      },
+    );
+  });
 }

--- a/test/emergency_whatsapp_test.dart
+++ b/test/emergency_whatsapp_test.dart
@@ -71,12 +71,16 @@ class FakeUrlLauncherPlatform extends UrlLauncherPlatform {
 }
 
 class RecordingFileService implements FileService {
-  RecordingFileService({List<String>? callLog, this.failuresRemaining = 0})
-    : callLog = callLog ?? [];
+  RecordingFileService({
+    List<String>? callLog,
+    this.failedResultsRemaining = 0,
+    this.exceptionsRemaining = 0,
+  }) : callLog = callLog ?? [];
 
   final List<String> callLog;
   final List<String> sharedMessages = [];
-  int failuresRemaining;
+  int failedResultsRemaining;
+  int exceptionsRemaining;
 
   @override
   Future<String?> download(
@@ -98,13 +102,18 @@ class RecordingFileService implements FileService {
   ) async {}
 
   @override
-  Future<void> shareTextOnly(String message) async {
+  Future<bool> shareTextOnly(String message) async {
     callLog.add('shareTextOnly');
-    if (failuresRemaining > 0) {
-      failuresRemaining--;
+    if (exceptionsRemaining > 0) {
+      exceptionsRemaining--;
       throw StateError('shareTextOnly failed');
     }
+    if (failedResultsRemaining > 0) {
+      failedResultsRemaining--;
+      return false;
+    }
     sharedMessages.add(message);
+    return true;
   }
 }
 
@@ -1318,10 +1327,10 @@ void main() {
   }, skip: !kIsWeb);
 
   testWidgets(
-    'PhonePage shows localized feedback and allows retry when sharing fails',
+    'PhonePage shows localized SOS feedback and allows retry when sharing is not confirmed',
     (tester) async {
       final geolocator = FakeGeolocatorPlatform();
-      final fileService = RecordingFileService(failuresRemaining: 1);
+      final fileService = RecordingFileService(failedResultsRemaining: 1);
       await _runLocationShareTest(
         geolocator,
         fileService,
@@ -1343,7 +1352,58 @@ void main() {
           await _tapLocationShare(tester);
 
           expect(tester.takeException(), isNull);
-          expect(find.text('משהו השתבש'), findsOneWidget);
+          final localizations = AppLocalizations.of(
+            tester.element(find.byType(PhonePage)),
+          )!;
+          expect(
+            find.text(localizations.sosShareLocationShareFailed),
+            findsOneWidget,
+          );
+          expect(fileService.sharedMessages, isEmpty);
+
+          await _tapLocationShare(tester);
+
+          expect(tester.takeException(), isNull);
+          expect(fileService.sharedMessages, hasLength(1));
+          expect(geolocator.currentPositionCalls, 2);
+        },
+      );
+    },
+  );
+
+  testWidgets(
+    'PhonePage shows localized SOS feedback and allows retry when sharing throws',
+    (tester) async {
+      final geolocator = FakeGeolocatorPlatform();
+      final fileService = RecordingFileService(exceptionsRemaining: 1);
+      await _runLocationShareTest(
+        geolocator,
+        fileService,
+        body: () async {
+          await tester.pumpWidget(
+            buildPhonePageTestApp(
+              userInformation: UserInformation(
+                gender: 'male',
+                location: 'IL',
+                service: FakePersistentMemoryService(),
+              ),
+              appInformation: AppInformation(),
+              phonePageData: _phonePageDataForLocationShare(),
+              locale: const Locale('he'),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await _tapLocationShare(tester);
+
+          expect(tester.takeException(), isNull);
+          final localizations = AppLocalizations.of(
+            tester.element(find.byType(PhonePage)),
+          )!;
+          expect(
+            find.text(localizations.sosShareLocationShareFailed),
+            findsOneWidget,
+          );
           expect(fileService.sharedMessages, isEmpty);
 
           await _tapLocationShare(tester);

--- a/test/file_service/file_service_test.dart
+++ b/test/file_service/file_service_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mazilon/AnalyticsService.dart';
@@ -49,10 +50,14 @@ class _FakeMemory implements PersistentMemoryService {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  const shareChannel = MethodChannel('dev.fluttercommunity.plus/share');
 
   late _FakeAnalytics analytics;
   late _FakeLogger logger;
   late _FakeMemory memory;
+  late List<MethodCall> shareCalls;
+  String? shareResult;
+  Object? shareError;
 
   setUp(() async {
     await GetIt.instance.reset();
@@ -70,9 +75,22 @@ void main() {
     GetIt.instance.registerSingleton<AnalyticsService>(analytics);
     GetIt.instance.registerSingleton<IncidentLoggerService>(logger);
     GetIt.instance.registerSingleton<PersistentMemoryService>(memory);
+    shareCalls = <MethodCall>[];
+    shareResult = 'com.example.share-target';
+    shareError = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(shareChannel, (call) async {
+      shareCalls.add(call);
+      if (shareError != null) {
+        throw shareError!;
+      }
+      return shareResult;
+    });
   });
 
   tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(shareChannel, null);
     await GetIt.instance.reset();
   });
 
@@ -177,18 +195,58 @@ void main() {
   });
 
   group('FileServiceImpl.shareTextOnly', () {
-    test('errors are caught and forwarded to logger', () async {
+    test('returns true and tracks analytics after a confirmed share', () async {
       final svc = FileServiceImpl();
-      await svc.shareTextOnly('hello');
-      // Either no error (plugin no-op) or logger captured. The catch branch
-      // is exercised either way; verify no uncaught exception.
-      expect(true, isTrue);
+      final shared = await svc.shareTextOnly('hello');
+
+      expect(shared, isTrue);
+      expect(shareCalls, hasLength(1));
+      expect(shareCalls.single.method, 'share');
+      expect(shareCalls.single.arguments, {'text': 'hello'});
+      expect(analytics.events, ['Text shared']);
+      expect(logger.logs, isEmpty);
     });
 
-    test('empty message tolerated', () async {
+    test('returns false without tracking when the sheet is dismissed',
+        () async {
+      shareResult = '';
       final svc = FileServiceImpl();
-      await svc.shareTextOnly('');
-      expect(true, isTrue);
+      final shared = await svc.shareTextOnly('hello');
+
+      expect(shared, isFalse);
+      expect(analytics.events, isEmpty);
+      expect(logger.logs, isEmpty);
+    });
+
+    test('returns false without tracking when no result is available',
+        () async {
+      shareResult = null;
+      final svc = FileServiceImpl();
+      final shared = await svc.shareTextOnly('hello');
+
+      expect(shared, isFalse);
+      expect(analytics.events, isEmpty);
+      expect(logger.logs, isEmpty);
+    });
+
+    test('logs and returns false when the native share call throws', () async {
+      shareError = StateError('native share unavailable');
+      final svc = FileServiceImpl();
+      final shared = await svc.shareTextOnly('hello');
+
+      expect(shared, isFalse);
+      expect(analytics.events, isEmpty);
+      expect(logger.logs.single, isA<PlatformException>());
+    });
+
+    test('logs and returns false for an invalid empty message', () async {
+      final svc = FileServiceImpl();
+      final shared = await svc.shareTextOnly('');
+
+      expect(shared, isFalse);
+      expect(shareCalls, isEmpty);
+      expect(analytics.events, isEmpty);
+      expect(logger.logs.single, isA<ArgumentError>());
     });
   });
 

--- a/test/form/shareform_test.mocks.dart
+++ b/test/form/shareform_test.mocks.dart
@@ -2072,14 +2072,14 @@ class MockFileService extends _i1.Mock implements _i7.FileService {
       ) as _i8.Future<String?>);
 
   @override
-  _i8.Future<void> shareTextOnly(String? message) => (super.noSuchMethod(
+  _i8.Future<bool> shareTextOnly(String? message) => (super.noSuchMethod(
         Invocation.method(
           #shareTextOnly,
           [message],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i8.Future<bool>.value(false),
+        returnValueForMissingStub: _i8.Future<bool>.value(false),
+      ) as _i8.Future<bool>);
 }
 
 /// A class which mocks [AnalyticsService].

--- a/test/helpers/widget_test_scaffold.dart
+++ b/test/helpers/widget_test_scaffold.dart
@@ -138,8 +138,9 @@ class NoopFileService implements FileService {
   }
 
   @override
-  Future<void> shareTextOnly(String message) async {
+  Future<bool> shareTextOnly(String message) async {
     shareTextCalls++;
+    return true;
   }
 }
 

--- a/test/l10n/arabic_catalog_coverage_test.dart
+++ b/test/l10n/arabic_catalog_coverage_test.dart
@@ -6,6 +6,13 @@ import 'package:flutter_test/flutter_test.dart';
 Map<String, dynamic> _arb(String path) =>
     jsonDecode(File(path).readAsStringSync()) as Map<String, dynamic>;
 
+const _englishFallbackKeys = {
+  'sosShareLocation',
+  'sosShareLocationTooltip',
+  'sosShareLocationMessage',
+  'sosShareLocationUnavailable',
+};
+
 Set<String> _messageKeys(String path) {
   final decoded = _arb(path);
   return decoded.keys
@@ -27,8 +34,7 @@ Map<String, Set<String>> _placeholderMetadata(String path) {
       continue;
     }
 
-    final placeholders =
-        metadata['placeholders'] ?? metadata['placeholder'];
+    final placeholders = metadata['placeholders'] ?? metadata['placeholder'];
     if (placeholders is Map<String, dynamic>) {
       placeholderMetadata[entry.key] = placeholders.keys.toSet();
     }
@@ -38,42 +44,54 @@ Map<String, Set<String>> _placeholderMetadata(String path) {
 }
 
 void main() {
-  test('Arabic ARB covers every English translation key', () {
-    final englishKeys = _messageKeys('lib/l10n/app_en.arb');
-    final arabicKeys = _messageKeys('lib/l10n/app_ar.arb');
+  test(
+    'Arabic ARB covers every English key except approved English fallbacks',
+    () {
+      final englishKeys = _messageKeys('lib/l10n/app_en.arb');
+      final arabicKeys = _messageKeys('lib/l10n/app_ar.arb');
 
-    final missingArabicKeys = englishKeys.difference(arabicKeys).toList()
-      ..sort();
-    final unexpectedArabicKeys = arabicKeys.difference(englishKeys).toList()
-      ..sort();
+      final missingArabicKeys = englishKeys.difference(arabicKeys).toList()
+        ..sort();
+      final unexpectedArabicKeys = arabicKeys.difference(englishKeys).toList()
+        ..sort();
 
-    expect(
-      missingArabicKeys,
-      isEmpty,
-      reason: 'Missing Arabic keys: ${missingArabicKeys.join(', ')}',
-    );
-    expect(
-      unexpectedArabicKeys,
-      isEmpty,
-      reason: 'Unexpected Arabic-only keys: ${unexpectedArabicKeys.join(', ')}',
-    );
-  });
+      expect(
+        missingArabicKeys,
+        _englishFallbackKeys.toList()..sort(),
+        reason:
+            'Arabic may omit only approved English fallback keys: ${missingArabicKeys.join(', ')}',
+      );
+      expect(
+        unexpectedArabicKeys,
+        isEmpty,
+        reason:
+            'Unexpected Arabic-only keys: ${unexpectedArabicKeys.join(', ')}',
+      );
+    },
+  );
 
   test('Arabic ARB preserves English placeholder metadata entries', () {
     final englishMetadata = _placeholderMetadata('lib/l10n/app_en.arb');
     final arabicMetadata = _placeholderMetadata('lib/l10n/app_ar.arb');
 
     final missingMetadataKeys =
-        englishMetadata.keys.toSet().difference(arabicMetadata.keys.toSet()).toList()
+        englishMetadata.keys
+            .toSet()
+            .difference(arabicMetadata.keys.toSet())
+            .toList()
           ..sort();
     final unexpectedMetadataKeys =
-        arabicMetadata.keys.toSet().difference(englishMetadata.keys.toSet()).toList()
+        arabicMetadata.keys
+            .toSet()
+            .difference(englishMetadata.keys.toSet())
+            .toList()
           ..sort();
 
     expect(
       missingMetadataKeys,
       isEmpty,
-      reason: 'Missing Arabic placeholder metadata keys: ${missingMetadataKeys.join(', ')}',
+      reason:
+          'Missing Arabic placeholder metadata keys: ${missingMetadataKeys.join(', ')}',
     );
     expect(
       unexpectedMetadataKeys,
@@ -94,21 +112,66 @@ void main() {
   test('Arabic ARB uses the reviewed UI wording for core navigation and actions', () {
     final arabic = _arb('lib/l10n/app_ar.arb');
 
-    expect(arabic['menu'], '{gender,select,male{القائمة} female{القائمة} other{القائمة}}');
-    expect(arabic['home'], '{gender,select,male{الرئيسية} female{الرئيسية} other{الرئيسية}}');
-    expect(arabic['closeButton'], '{gender,select,male{إلغاء} female{إلغاء} other{إلغاء}}');
-    expect(arabic['confirmButton'], '{gender,select,male{تأكيد} female{تأكيد} other{تأكيد}}');
-    expect(arabic['saveButton'], '{gender,select,male{حفظ} female{حفظ} other{حفظ}}');
-    expect(arabic['deleteButton'], '{gender,select,male{حذف} female{حذف} other{حذف}}');
-    expect(arabic['nextButton'], '{gender,select,male{متابعة} female{متابعة} other{متابعة}}');
-    expect(arabic['skipButton'], '{gender,select,male{تخطي} female{تخطي} other{تخطي}}');
-    expect(arabic['personalPlanPageFinish'], '{gender,select,male{إنهاء} female{إنهاء} other{إنهاء}}');
-    expect(arabic['dialButton'], '{gender,select,male{اتصال} female{اتصال} other{اتصال}}');
-    expect(arabic['select'], '{gender,select,male{اختيار} female{اختيار} other{اختيار}}');
-    expect(arabic['addFormEdit'], '{gender,select,male{تعديل} female{تعديل} other{تعديل}}');
-    expect(arabic['addFormPageTemplateAdd'], '{gender,select,male{إضافة} female{إضافة} other{إضافة}}');
-    expect(arabic['homePageBack'], '{gender,select,male{إغلاق} female{إغلاق} other{إغلاق}}');
-    expect(arabic['introductionFormFirstPageSkip'], '{gender,select,male{تخطي} female{تخطي} other{تخطي}}');
+    expect(
+      arabic['menu'],
+      '{gender,select,male{القائمة} female{القائمة} other{القائمة}}',
+    );
+    expect(
+      arabic['home'],
+      '{gender,select,male{الرئيسية} female{الرئيسية} other{الرئيسية}}',
+    );
+    expect(
+      arabic['closeButton'],
+      '{gender,select,male{إلغاء} female{إلغاء} other{إلغاء}}',
+    );
+    expect(
+      arabic['confirmButton'],
+      '{gender,select,male{تأكيد} female{تأكيد} other{تأكيد}}',
+    );
+    expect(
+      arabic['saveButton'],
+      '{gender,select,male{حفظ} female{حفظ} other{حفظ}}',
+    );
+    expect(
+      arabic['deleteButton'],
+      '{gender,select,male{حذف} female{حذف} other{حذف}}',
+    );
+    expect(
+      arabic['nextButton'],
+      '{gender,select,male{متابعة} female{متابعة} other{متابعة}}',
+    );
+    expect(
+      arabic['skipButton'],
+      '{gender,select,male{تخطي} female{تخطي} other{تخطي}}',
+    );
+    expect(
+      arabic['personalPlanPageFinish'],
+      '{gender,select,male{إنهاء} female{إنهاء} other{إنهاء}}',
+    );
+    expect(
+      arabic['dialButton'],
+      '{gender,select,male{اتصال} female{اتصال} other{اتصال}}',
+    );
+    expect(
+      arabic['select'],
+      '{gender,select,male{اختيار} female{اختيار} other{اختيار}}',
+    );
+    expect(
+      arabic['addFormEdit'],
+      '{gender,select,male{تعديل} female{تعديل} other{تعديل}}',
+    );
+    expect(
+      arabic['addFormPageTemplateAdd'],
+      '{gender,select,male{إضافة} female{إضافة} other{إضافة}}',
+    );
+    expect(
+      arabic['homePageBack'],
+      '{gender,select,male{إغلاق} female{إغلاق} other{إغلاق}}',
+    );
+    expect(
+      arabic['introductionFormFirstPageSkip'],
+      '{gender,select,male{تخطي} female{تخطي} other{تخطي}}',
+    );
     expect(arabic['shareButtonText'], 'مشاركة');
     expect(
       arabic['inspirationalQuotesNo34'],

--- a/test/l10n/arabic_catalog_coverage_test.dart
+++ b/test/l10n/arabic_catalog_coverage_test.dart
@@ -6,14 +6,6 @@ import 'package:flutter_test/flutter_test.dart';
 Map<String, dynamic> _arb(String path) =>
     jsonDecode(File(path).readAsStringSync()) as Map<String, dynamic>;
 
-const _englishFallbackKeys = {
-  'sosShareLocation',
-  'sosShareLocationTooltip',
-  'sosShareLocationMessage',
-  'sosShareLocationUnavailable',
-  'sosShareLocationShareFailed',
-};
-
 Set<String> _messageKeys(String path) {
   final decoded = _arb(path);
   return decoded.keys
@@ -46,7 +38,7 @@ Map<String, Set<String>> _placeholderMetadata(String path) {
 
 void main() {
   test(
-    'Arabic ARB covers every English key except approved English fallbacks',
+    'Arabic ARB covers every English key',
     () {
       final englishKeys = _messageKeys('lib/l10n/app_en.arb');
       final arabicKeys = _messageKeys('lib/l10n/app_ar.arb');
@@ -58,9 +50,8 @@ void main() {
 
       expect(
         missingArabicKeys,
-        _englishFallbackKeys.toList()..sort(),
-        reason:
-            'Arabic may omit only approved English fallback keys: ${missingArabicKeys.join(', ')}',
+        isEmpty,
+        reason: 'Missing Arabic keys: ${missingArabicKeys.join(', ')}',
       );
       expect(
         unexpectedArabicKeys,
@@ -70,6 +61,22 @@ void main() {
       );
     },
   );
+
+  test('Arabic ARB provides approved SOS location-sharing copy', () {
+    final arabic = _arb('lib/l10n/app_ar.arb');
+
+    expect(arabic['sosShareLocation'], 'مشاركة الموقع');
+    expect(arabic['sosShareLocationTooltip'], 'مشاركة موقعك الحالي');
+    expect(arabic['sosShareLocationMessage'], 'أنا هنا وأحتاج إلى مساعدتك.');
+    expect(
+      arabic['sosShareLocationUnavailable'],
+      'تعذّر مشاركة موقعك. ستتم مشاركة رسالة طلب المساعدة بدون الموقع.',
+    );
+    expect(
+      arabic['sosShareLocationShareFailed'],
+      'تعذّر مشاركة رسالة طلب المساعدة الخاصة بك. يُرجى المحاولة مرة أخرى.',
+    );
+  });
 
   test('Arabic ARB preserves English placeholder metadata entries', () {
     final englishMetadata = _placeholderMetadata('lib/l10n/app_en.arb');

--- a/test/l10n/arabic_catalog_coverage_test.dart
+++ b/test/l10n/arabic_catalog_coverage_test.dart
@@ -11,6 +11,7 @@ const _englishFallbackKeys = {
   'sosShareLocationTooltip',
   'sosShareLocationMessage',
   'sosShareLocationUnavailable',
+  'sosShareLocationShareFailed',
 };
 
 Set<String> _messageKeys(String path) {

--- a/test/menu_change_index_test.dart
+++ b/test/menu_change_index_test.dart
@@ -69,7 +69,7 @@ class _FakeFiles implements FileService {
   @override
   Future<String?> download(titles, subTitles, texts, fmt, dir) async => null;
   @override
-  Future<void> shareTextOnly(message) async {}
+  Future<bool> shareTextOnly(message) async => true;
 }
 
 // We'll register the test scaffold's NoopImagePickerService below in setUp.

--- a/test/menu_test.dart
+++ b/test/menu_test.dart
@@ -82,7 +82,7 @@ class _FakeFileService implements FileService {
   ) async =>
       null;
   @override
-  Future<void> shareTextOnly(String message) async {}
+  Future<bool> shareTextOnly(String message) async => true;
 }
 
 void main() {


### PR DESCRIPTION
# User description
## Summary

- Add a foreground-only Share Location action between personal contacts and emergency numbers on the SOS page.
- Share a one-time high-accuracy location snapshot and the localized help message through the native system share sheet.
- Fall back to sharing the help text without location when location is unavailable.

## Why

In an SOS situation, people need a fast way to share where they are while retaining control over the receiving app and recipient.

## Root cause

The SOS page previously supported calls and text sharing but had no device-location capture or location-sharing action.

## Validation

- Focused SOS and localization tests: 33 passed.
- Full unit suite: 752 passed, 8 skipped; coverage gate passed at 89.88%.
- `flutter analyze` passed.
- Android debug APK and web debug builds passed.

Uses the resolver-compatible `geolocator ^14.0.2`; `^14.0.3` conflicts with the repository's fixed `file_picker` dependency, so no unrelated dependency upgrade or override was introduced.

Closes #217

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
PhonePageState_build_("_PhonePageState.build"):::modified
AppLocalizations_sosShareLocation_("AppLocalizations.sosShareLocation"):::added
PhonePageState_shareCurrentLocation_("_PhonePageState._shareCurrentLocation"):::added
GEOLocator_("GEOLocator"):::added
GET_IT_("GET_IT"):::added
FileService_shareTextOnly_("FileService.shareTextOnly"):::modified
FileServiceImpl_shareTextOnly_("FileServiceImpl.shareTextOnly"):::modified
SHARE_PLUS_("SHARE_PLUS"):::modified
PhonePageState_build_ -- "Uses new sosShareLocation text for share-location button label." --> AppLocalizations_sosShareLocation_
PhonePageState_build_ -- "Wires button onTap to current-location sharing flow." --> PhonePageState_shareCurrentLocation_
PhonePageState_shareCurrentLocation_ -- "Checks permissions and reads current GPS to build map link." --> GEOLocator_
PhonePageState_shareCurrentLocation_ -- "Resolves FileService via GetIt before initiating share operation." --> GET_IT_
PhonePageState_shareCurrentLocation_ -- "Calls shareTextOnly with SOS text, returns share success status." --> FileService_shareTextOnly_
FileServiceImpl_shareTextOnly_ -- "Shares message text via SharePlus; returns false on non-success." --> SHARE_PLUS_
FileServiceImpl_shareTextOnly_ -- "Uses GetIt analytics/logger; returns false when sharing throws." --> GET_IT_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Add a foreground-only SOS share action in <code>PhonePage</code> that captures a single high-accuracy location with <code>Geolocator</code>, appends a map link to the help text, and hands it to <code>FileService</code> for the native share sheet. Update platform permissions and dependency wiring, and fall back to text-only sharing when location or sharing is unavailable.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/304?tool=ast&topic=SOS+sharing>SOS sharing</a>
        </td><td>Add a location-sharing action to <code>PhonePage</code>, confirm shares through <code>FileService</code>, and wire in <code>geolocator</code> plus Android/iOS permission support for a one-time foreground position fix.<details><summary>Modified files (8)</summary><ul><li>android/app/src/main/AndroidManifest.xml</li>
<li>docs/adr/ADR-009-sos-location-sharing-dependency.md</li>
<li>ios/Podfile</li>
<li>ios/Runner/Info.plist</li>
<li>lib/file_service.dart</li>
<li>lib/pages/phone.dart</li>
<li>pubspec.lock</li>
<li>pubspec.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(sos): confirm nati...</td><td>July 31, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Speed up iOS integrati...</td><td>May 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/304?tool=ast&topic=L10n+and+tests>L10n and tests</a>
        </td><td>Add localized SOS copy and expand coverage for location-sharing success, permission fallback, share failures, and platform-specific behavior.<details><summary>Modified files (20)</summary><ul><li>integration_test/custom_categories_e2e_test.dart</li>
<li>lib/l10n/app_ar.arb</li>
<li>lib/l10n/app_en.arb</li>
<li>lib/l10n/app_he.arb</li>
<li>lib/l10n/app_localizations.dart</li>
<li>lib/l10n/app_localizations_ar.dart</li>
<li>lib/l10n/app_localizations_en.dart</li>
<li>lib/l10n/app_localizations_he.dart</li>
<li>test/MenuTest/Feelgood/feelGood_test.mocks.dart</li>
<li>test/MenuTest/Wellness/wellnessTools_test.mocks.dart</li>
<li>test/MenuTest/reminder_visibility_test.dart</li>
<li>test/MenuTest/shareAndDownload/share_and_download_test.mocks.dart</li>
<li>test/a11y/phase_b_semantics_test.dart</li>
<li>test/emergency_whatsapp_test.dart</li>
<li>test/file_service/file_service_test.dart</li>
<li>test/form/shareform_test.mocks.dart</li>
<li>test/helpers/widget_test_scaffold.dart</li>
<li>test/l10n/arabic_catalog_coverage_test.dart</li>
<li>test/menu_change_index_test.dart</li>
<li>test/menu_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(l10n): localize Ar...</td><td>July 31, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Implement UX gaps reme...</td><td>June 07, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/304?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>