### PR TITLE
fix(home): reorder gratitude and qualities lists

### DIFF
--- a/lib/MainPageHelpers/MainPageList/list_utils.dart
+++ b/lib/MainPageHelpers/MainPageList/list_utils.dart
@@ -40,11 +40,13 @@ Map<String, dynamic> getLocalizedTextForLists(locale, gender, type) {
 
 List<String> todayThankYousFunc(List<String> thankYous, List<String> dates) {
   List<String> todayThankYous = [];
-  DateTime now = DateTime.now();
-  String formattedDate = intl.DateFormat('yyyy-MM-dd – kk:mm').format(now);
+  final todayDate = intl.DateFormat('yyyy-MM-dd').format(DateTime.now());
+  final itemCount = thankYous.length < dates.length
+      ? thankYous.length
+      : dates.length;
 
-  for (int i = 0; i < dates.length; i++) {
-    if (dates[i].substring(0, 10) == formattedDate.substring(0, 10)) {
+  for (int i = 0; i < itemCount; i++) {
+    if (dates[i].startsWith(todayDate)) {
       todayThankYous.add(thankYous[i]);
     }
   }

--- a/lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart
+++ b/lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart
@@ -49,15 +49,17 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
     final gender = userInfoProvider.gender.isEmpty
         ? 'other'
         : userInfoProvider.gender;
+    final thanks = userInfoProvider.thanks['thanks'] ?? <String>[];
+    final dates = userInfoProvider.thanks['dates'] ?? <String>[];
     final suggestions = widget.pageCode == PagesCode.QualitiesList
         ? retrieveTraitsList(appLocale, gender)
         : retrieveThanksList(appLocale, gender);
     final existingItems = widget.pageCode == PagesCode.QualitiesList
         ? userInfoProvider.positiveTraits
-        : todayThankYousFunc(
-            userInfoProvider.thanks['thanks'] ?? [],
-            userInfoProvider.thanks['dates'] ?? [],
-          );
+        : _todayThankYouIndexes(
+            thanks,
+            dates,
+          ).map((index) => thanks[index]).toList();
     final eligibleSuggestions = <String>[];
 
     for (final suggestion in suggestions) {
@@ -114,16 +116,14 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
   }
 
   List<int> _todayThankYouIndexes(List<String> thankYous, List<String> dates) {
-    final formattedDate = intl.DateFormat(
-      'yyyy-MM-dd – kk:mm',
-    ).format(DateTime.now());
+    final todayDate = intl.DateFormat('yyyy-MM-dd').format(DateTime.now());
     final itemCount = thankYous.length < dates.length
         ? thankYous.length
         : dates.length;
     final indexes = <int>[];
 
     for (var index = 0; index < itemCount; index++) {
-      if (dates[index].substring(0, 10) == formattedDate.substring(0, 10)) {
+      if (dates[index].startsWith(todayDate)) {
         indexes.add(index);
       }
     }

--- a/lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart
+++ b/lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:intl/intl.dart' as intl;
 
 import 'package:mazilon/MainPageHelpers/MainPageList/mainpage_list_body_widget.dart';
 import 'package:mazilon/MainPageHelpers/MainPageList/list_utils.dart';
@@ -32,11 +33,102 @@ class ListWidget extends StatefulWidget {
 }
 
 class _ListWidgetState extends LPExtendedState<ListWidget> {
-  List<String> todayThankYous = [];
-  List<String> listItems = [];
+  List<String> _homeSuggestions = [];
+  String _suggestionCandidateKey = '';
+  bool _suggestionsInitialized = false;
+
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _refreshHomeSuggestions(
+      Provider.of<UserInformation>(context, listen: false),
+    );
+  }
+
+  List<String> _eligibleSuggestions(UserInformation userInfoProvider) {
+    final gender = userInfoProvider.gender.isEmpty
+        ? 'other'
+        : userInfoProvider.gender;
+    final suggestions = widget.pageCode == PagesCode.QualitiesList
+        ? retrieveTraitsList(appLocale, gender)
+        : retrieveThanksList(appLocale, gender);
+    final existingItems = widget.pageCode == PagesCode.QualitiesList
+        ? userInfoProvider.positiveTraits
+        : todayThankYousFunc(
+            userInfoProvider.thanks['thanks'] ?? [],
+            userInfoProvider.thanks['dates'] ?? [],
+          );
+    final eligibleSuggestions = <String>[];
+
+    for (final suggestion in suggestions) {
+      if (!existingItems.contains(suggestion) &&
+          !eligibleSuggestions.contains(suggestion)) {
+        eligibleSuggestions.add(suggestion);
+      }
+    }
+
+    return eligibleSuggestions;
+  }
+
+  bool _sameOrder(List<String> first, List<String> second) {
+    if (first.length != second.length) {
+      return false;
+    }
+
+    for (var index = 0; index < first.length; index++) {
+      if (first[index] != second[index]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  List<String> _selectHomeSuggestions(List<String> candidates) {
+    final shuffledCandidates = List<String>.from(candidates)..shuffle();
+    final selectedSuggestions = shuffledCandidates.take(3).toList();
+
+    if (_sameOrder(selectedSuggestions, _homeSuggestions) &&
+        selectedSuggestions.length > 1) {
+      selectedSuggestions.add(selectedSuggestions.removeAt(0));
+    }
+
+    return selectedSuggestions;
+  }
+
+  void _refreshHomeSuggestions(
+    UserInformation userInfoProvider, {
+    bool force = false,
+  }) {
+    final candidates = _eligibleSuggestions(userInfoProvider);
+    final candidateKey = candidates.join('\u0000');
+    if (!force &&
+        _suggestionsInitialized &&
+        candidateKey == _suggestionCandidateKey) {
+      return;
+    }
+
+    _homeSuggestions = _selectHomeSuggestions(candidates);
+    _suggestionCandidateKey = candidateKey;
+    _suggestionsInitialized = true;
+  }
+
+  List<int> _todayThankYouIndexes(List<String> thankYous, List<String> dates) {
+    final formattedDate = intl.DateFormat(
+      'yyyy-MM-dd – kk:mm',
+    ).format(DateTime.now());
+    final itemCount = thankYous.length < dates.length
+        ? thankYous.length
+        : dates.length;
+    final indexes = <int>[];
+
+    for (var index = 0; index < itemCount; index++) {
+      if (dates[index].substring(0, 10) == formattedDate.substring(0, 10)) {
+        indexes.add(index);
+      }
+    }
+
+    return indexes;
   }
 
   void showThankYouPopup(UserInformation userInfoProvider) {
@@ -84,25 +176,15 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
         'thanks': thankyousTemp,
         'dates': datesTemp,
       });
-
-      todayThankYous = todayThankYousFunc(thankyousTemp, datesTemp);
+      _refreshHomeSuggestions(userInfoProvider);
     });
   }
 
   void editTraitsState(positivetraitsTemp, userInfoProvider) {
     setState(() {
       userInfoProvider.updatePositiveTraits(positivetraitsTemp);
+      _refreshHomeSuggestions(userInfoProvider);
     });
-  }
-
-  Function getSuggestionBox(appLocale) {
-    if (widget.pageCode == PagesCode.QualitiesList) {
-      return (stopShowingNumber, gender) =>
-          buildPositiveTraitItemSug(stopShowingNumber, gender, appLocale);
-    } else {
-      return (stopShowingNumber, gender) =>
-          buildThanksItemSug(stopShowingNumber, gender, appLocale);
-    }
   }
 
   void editTrait(String title, [String text = '', int index = 0]) {
@@ -147,76 +229,82 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
   }
 
   Function(int index) editItemFunction(
-    userInfoProvider,
-    thanksListLength,
-    traitsListlength,
+    UserInformation userInfoProvider,
+    List<int> sourceIndexes,
   ) {
     if (widget.pageCode == PagesCode.GratitudeJournal) {
-      return (index) => editThanks(
-        appLocale.thanks,
-        todayThankYous[index],
-        thanksListLength - todayThankYous.length + index,
-      );
+      return (index) {
+        final sourceIndex = sourceIndexes[index];
+        return editThanks(
+          appLocale.thanks,
+          (userInfoProvider.thanks['thanks'] ?? [])[sourceIndex],
+          sourceIndex,
+        );
+      };
     } else {
-      return (index) => editTrait(
-        appLocale.trait,
-        userInfoProvider.positiveTraits[index],
-        traitsListlength - userInfoProvider.positiveTraits.length + index,
-      );
+      return (index) {
+        final sourceIndex = sourceIndexes[index];
+        return editTrait(
+          appLocale.trait,
+          userInfoProvider.positiveTraits[sourceIndex],
+          sourceIndex,
+        );
+      };
     }
   }
 
   Function(int index) removeItemFunction(
-    userInfoProvider,
-    thanksListLength,
-    traitsListlength,
+    UserInformation userInfoProvider,
+    List<int> sourceIndexes,
   ) {
     if (widget.pageCode == PagesCode.GratitudeJournal) {
       return (index) => removeThankYou(
-        thanksListLength - todayThankYous.length + index,
+        sourceIndexes[index],
         userInfoProvider,
         editThanksState,
       );
     } else {
       return (index) => removePositiveTrait(
-        traitsListlength - userInfoProvider.positiveTraits.length + index,
+        sourceIndexes[index],
         userInfoProvider,
         editTraitsState,
       );
     }
   }
 
-  Widget buildThanksItemSug(stopShowingNumber, gender, appLocale) {
+  Widget buildThanksItemSug(String suggestion, String gender) {
     return ThanksItemSuggested(
-      stopShowing: stopShowingNumber,
-      add: (thankYou, userInfoProvider) => {
+      stopShowing: 0,
+      add: (thankYou, userInfoProvider) {
         addThankYou(
           thankYou,
           userInfoProvider,
           editThanksState,
           showThankYouPopup,
-        ),
+        );
       },
-      inputText: "",
-      fullSuggestionList: retrieveThanksList(
-        appLocale,
-        gender == "" ? "other" : gender,
-      ),
+      inputText: suggestion,
+      fullSuggestionList: retrieveThanksList(appLocale, gender),
     );
   }
 
-  Widget buildPositiveTraitItemSug(stopShowingNumber, gender, appLocale) {
+  Widget buildPositiveTraitItemSug(String suggestion, String gender) {
     return PositiveTraitItemSug(
-      stopShowing: stopShowingNumber,
-      add: (trait, userInfoProvider) => {
-        addPositiveTrait(trait, userInfoProvider, editTraitsState),
+      stopShowing: 0,
+      add: (trait, userInfoProvider) {
+        addPositiveTrait(trait, userInfoProvider, editTraitsState);
       },
-      inputText: "",
-      fullSuggestionList: retrieveTraitsList(
-        appLocale,
-        gender == "" ? "other" : gender,
-      ),
+      inputText: suggestion,
+      fullSuggestionList: retrieveTraitsList(appLocale, gender),
     );
+  }
+
+  Widget buildSuggestion(String suggestion, String gender) {
+    if (widget.pageCode == PagesCode.QualitiesList) {
+      return buildPositiveTraitItemSug(suggestion, gender);
+    }
+
+    return buildThanksItemSug(suggestion, gender);
   }
 
   void addItemFunction() {
@@ -236,24 +324,29 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
       context,
       listen: true,
     );
-    final gender = userInfoProvider.gender;
-    final traitsListlength = userInfoProvider.positiveTraits.length;
-    final thanksListLength = userInfoProvider.thanks['thanks']?.length ?? 0;
-    todayThankYous = todayThankYousFunc(
-      userInfoProvider.thanks["thanks"] ?? [],
-      userInfoProvider.thanks["dates"] ?? [],
-    );
+    final gender = userInfoProvider.gender.isEmpty
+        ? 'other'
+        : userInfoProvider.gender;
+    final thanks = userInfoProvider.thanks['thanks'] ?? <String>[];
+    final dates = userInfoProvider.thanks['dates'] ?? <String>[];
+    final sourceIndexes = widget.pageCode == PagesCode.GratitudeJournal
+        ? _todayThankYouIndexes(thanks, dates).reversed.toList()
+        : List<int>.generate(
+            userInfoProvider.positiveTraits.length,
+            (index) => userInfoProvider.positiveTraits.length - index - 1,
+          );
+    final listItems = sourceIndexes
+        .map(
+          (index) => widget.pageCode == PagesCode.GratitudeJournal
+              ? thanks[index]
+              : userInfoProvider.positiveTraits[index],
+        )
+        .toList();
     final pageData = getLocalizedTextForLists(
       appLocale,
       gender,
       widget.pageCode,
     );
-    final listItems = getListItems(
-      widget.pageCode,
-      userInfoProvider,
-      todayThankYous,
-    );
-    final sugBox = getSuggestionBox(appLocale);
     return SizedBox(
       // the width of the widget is 800 if the screen width is more than 1000, otherwise it is the screen width
       width: MediaQuery.of(context).size.width > 1000
@@ -303,28 +396,40 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
             ),
             // gap between the section bar and the trait list
             const SizedBox(height: 10),
-            // a suggested trait with add button
-            sugBox(1, gender),
-            sugBox(2, gender),
-            sugBox(3, gender),
             ListBodyWidget(
               listItems: listItems,
-              editItems: editItemFunction(
-                userInfoProvider,
-                thanksListLength,
-                traitsListlength,
-              ),
-              removeItems: removeItemFunction(
-                userInfoProvider,
-                thanksListLength,
-                traitsListlength,
-              ),
+              editItems: editItemFunction(userInfoProvider, sourceIndexes),
+              removeItems: removeItemFunction(userInfoProvider, sourceIndexes),
             ),
-            // the list of the traits
-            // the see all button
             ShowAllButton(
               onTabTapped: widget.onTabTapped,
               pageCode: widget.pageCode,
+            ),
+            for (final suggestion in _homeSuggestions)
+              buildSuggestion(suggestion, gender),
+            TextButton(
+              onPressed: () {
+                setState(() {
+                  _refreshHomeSuggestions(userInfoProvider, force: true);
+                });
+              },
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Text(
+                    appLocale.otherSuggestions(gender),
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Theme.of(context).colorScheme.tertiary,
+                    ),
+                  ),
+                  const SizedBox(width: 1.0),
+                  Icon(
+                    Icons.refresh,
+                    color: Theme.of(context).colorScheme.tertiary,
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -186,21 +186,17 @@ class _HomeState extends LPExtendedState<Home> {
                     ),
 
                     const SizedBox(height: 20),
+                    //This is the main widget for the gratitude journal
+                    ListWidget(
+                      onTabTapped: widget.changeCurrentIndex,
+                      pageCode: PagesCode.GratitudeJournal,
+                    ),
+                    const SizedBox(height: 20),
                     //This is the main widget for the positive traits list
                     ListWidget(
                       onTabTapped: widget.changeCurrentIndex,
                       pageCode: PagesCode.QualitiesList,
                     ),
-                    //  TraitListWidget(
-                    //   onTabTapped: widget.changeCurrentIndex,
-                    // ),
-                    const SizedBox(height: 20),
-                    ListWidget(
-                      onTabTapped: widget.changeCurrentIndex,
-                      pageCode: PagesCode.GratitudeJournal,
-                    ),
-                    //This is the main widget for the thank yous list
-                    //  ThanksListWidget(onTabTapped: widget.changeCurrentIndex),
                   ],
                 ),
               ),

--- a/lib/util/Thanks/thanksItemSug.dart
+++ b/lib/util/Thanks/thanksItemSug.dart
@@ -41,10 +41,12 @@ class _ThanksItemSuggestedState extends LPExtendedState<ThanksItemSuggested> {
   // function to get the thank yous written today (the date of the thank you is today)
   List<String> todayThankYousFunc(List<String> thankYous, List<String> dates) {
     List<String> todayThankYous = [];
-    DateTime now = DateTime.now();
-    String formattedDate = DateFormat('yyyy-MM-dd – kk:mm').format(now);
-    for (int i = 0; i < dates.length; i++) {
-      if (dates[i].substring(0, 10) == formattedDate.substring(0, 10)) {
+    final todayDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    final itemCount = thankYous.length < dates.length
+        ? thankYous.length
+        : dates.length;
+    for (int i = 0; i < itemCount; i++) {
+      if (dates[i].startsWith(todayDate)) {
         todayThankYous.add(thankYous[i]);
       }
     }

--- a/test/MainPageHelpers/mainpage_list_order_test.dart
+++ b/test/MainPageHelpers/mainpage_list_order_test.dart
@@ -1,0 +1,344 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mazilon/MainPageHelpers/MainPageList/mainpage_list_body_widget.dart';
+import 'package:mazilon/MainPageHelpers/MainPageList/mainpage_list_item_number_widget.dart';
+import 'package:mazilon/MainPageHelpers/MainPageList/mainpage_list_item_widget.dart';
+import 'package:mazilon/MainPageHelpers/MainPageList/mainpage_list_widget.dart';
+import 'package:mazilon/MainPageHelpers/show_all_button.dart';
+import 'package:mazilon/global_enums.dart';
+import 'package:mazilon/util/Thanks/AddForm.dart';
+import 'package:mazilon/util/Thanks/thanksItemSug.dart';
+import 'package:mazilon/util/Traits/positiveTraitItemSug.dart';
+import 'package:mazilon/util/suggestion_add_button.dart';
+import 'package:mazilon/util/userInformation.dart';
+
+import '../helpers/widget_test_scaffold.dart';
+
+String _date(DateTime date, String time) {
+  final year = date.year.toString().padLeft(4, '0');
+  final month = date.month.toString().padLeft(2, '0');
+  final day = date.day.toString().padLeft(2, '0');
+  return '$year-$month-$day – $time';
+}
+
+Future<void> _pumpListWidget(
+  WidgetTester tester, {
+  required UserInformation user,
+  required PagesCode pageCode,
+}) {
+  return pumpWithProviders(
+    tester,
+    Scaffold(
+      body: ListWidget(onTabTapped: (_, _) {}, pageCode: pageCode),
+    ),
+    userInformation: user,
+    surfaceSize: const Size(800, 2400),
+  );
+}
+
+List<String> _traitSuggestions(WidgetTester tester) {
+  return tester
+      .widgetList<PositiveTraitItemSug>(find.byType(PositiveTraitItemSug))
+      .map((widget) => widget.inputText)
+      .toList();
+}
+
+List<String> _thanksSuggestions(WidgetTester tester) {
+  return tester
+      .widgetList<ThanksItemSuggested>(find.byType(ThanksItemSuggested))
+      .map((widget) => widget.inputText)
+      .toList();
+}
+
+Finder _refreshButton() {
+  return find.ancestor(
+    of: find.text('other suggestions'),
+    matching: find.byType(TextButton),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late TestServiceLocators services;
+
+  setUp(() {
+    services = registerTestServices(locale: 'en');
+  });
+
+  tearDown(resetTestServices);
+
+  UserInformation user({
+    List<String> traits = const [],
+    Map<String, List<String>> thanks = const {},
+  }) {
+    return UserInformation(
+      service: services.memory,
+      gender: 'other',
+      positiveTraits: List<String>.from(traits),
+      thanks: {
+        'thanks': List<String>.from(thanks['thanks'] ?? const []),
+        'dates': List<String>.from(thanks['dates'] ?? const []),
+      },
+    );
+  }
+
+  testWidgets('places saved traits before show all and refreshed suggestions', (
+    tester,
+  ) async {
+    final testUser = user(traits: ['older', 'newer']);
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.QualitiesList,
+    );
+
+    final rows = tester
+        .widgetList<MainpageListItemWidget>(find.byType(MainpageListItemWidget))
+        .toList();
+    expect(rows.map((row) => row.item), ['newer', 'older']);
+    expect(
+      tester
+          .widget<ListItemNumberWidget>(find.byType(ListItemNumberWidget).first)
+          .index,
+      0,
+    );
+
+    final listBodyY = tester.getTopLeft(find.byType(ListBodyWidget)).dy;
+    final showAllY = tester.getTopLeft(find.byType(ShowAllButton)).dy;
+    final suggestionY = tester
+        .getTopLeft(find.byType(PositiveTraitItemSug).first)
+        .dy;
+    final refreshY = tester.getTopLeft(_refreshButton()).dy;
+
+    expect(listBodyY, lessThan(showAllY));
+    expect(showAllY, lessThan(suggestionY));
+    expect(suggestionY, lessThan(refreshY));
+  });
+
+  testWidgets('renders today gratitude entries newest first', (tester) async {
+    final now = DateTime.now();
+    final testUser = user(
+      thanks: {
+        'thanks': ['older today', 'newer today'],
+        'dates': [_date(now, '09:00'), _date(now, '10:00')],
+      },
+    );
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.GratitudeJournal,
+    );
+
+    final rows = tester
+        .widgetList<MainpageListItemWidget>(find.byType(MainpageListItemWidget))
+        .toList();
+    expect(rows.map((row) => row.item), ['newer today', 'older today']);
+    expect(_thanksSuggestions(tester), hasLength(3));
+    expect(_refreshButton(), findsOneWidget);
+  });
+
+  testWidgets(
+    'maps reversed qualities edits and deletes to their source rows',
+    (tester) async {
+      final testUser = user(traits: ['oldest', 'middle', 'newest']);
+
+      await _pumpListWidget(
+        tester,
+        user: testUser,
+        pageCode: PagesCode.QualitiesList,
+      );
+
+      tester
+          .widget<MainpageListItemWidget>(
+            find.byType(MainpageListItemWidget).at(2),
+          )
+          .onEdit();
+      await tester.pumpAndSettle();
+      expect(
+        tester
+            .widget<TextFormField>(find.byType(TextFormField))
+            .controller
+            ?.text,
+        'oldest',
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'renamed oldest');
+      await tester.tap(
+        find
+            .descendant(
+              of: find.byType(AddForm),
+              matching: find.byType(TextButton),
+            )
+            .last,
+      );
+      await tester.pumpAndSettle();
+      expect(testUser.positiveTraits, ['renamed oldest', 'middle', 'newest']);
+
+      tester
+          .widget<MainpageListItemWidget>(
+            find.byType(MainpageListItemWidget).first,
+          )
+          .onDelete();
+      await tester.pumpAndSettle();
+      expect(testUser.positiveTraits, ['renamed oldest', 'middle']);
+    },
+  );
+
+  testWidgets(
+    'maps filtered gratitude edits and deletes to their source rows',
+    (tester) async {
+      final now = DateTime.now();
+      final yesterday = now.subtract(const Duration(days: 1));
+      final testUser = user(
+        thanks: {
+          'thanks': [
+            'duplicate',
+            'historic',
+            'middle today',
+            'duplicate',
+            'older historic',
+          ],
+          'dates': [
+            _date(now, '08:00'),
+            _date(yesterday, '11:00'),
+            _date(now, '09:00'),
+            _date(now, '10:00'),
+            _date(yesterday, '12:00'),
+          ],
+        },
+      );
+
+      await _pumpListWidget(
+        tester,
+        user: testUser,
+        pageCode: PagesCode.GratitudeJournal,
+      );
+
+      tester
+          .widget<MainpageListItemWidget>(
+            find.byType(MainpageListItemWidget).at(2),
+          )
+          .onEdit();
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField), 'edited source zero');
+      await tester.tap(
+        find
+            .descendant(
+              of: find.byType(AddForm),
+              matching: find.byType(TextButton),
+            )
+            .last,
+      );
+      await tester.pumpAndSettle();
+      expect(testUser.thanks['thanks']?[0], 'edited source zero');
+      expect(testUser.thanks['dates']?[0], _date(now, '08:00'));
+
+      tester
+          .widget<MainpageListItemWidget>(
+            find.byType(MainpageListItemWidget).first,
+          )
+          .onDelete();
+      await tester.pumpAndSettle();
+      expect(testUser.thanks['thanks'], [
+        'edited source zero',
+        'historic',
+        'middle today',
+        'older historic',
+      ]);
+      expect(testUser.thanks['dates'], [
+        _date(now, '08:00'),
+        _date(yesterday, '11:00'),
+        _date(now, '09:00'),
+        _date(yesterday, '12:00'),
+      ]);
+    },
+  );
+
+  testWidgets(
+    'refreshes qualities suggestions and excludes a newly added one',
+    (tester) async {
+      final testUser = user(traits: <String>[]);
+
+      await _pumpListWidget(
+        tester,
+        user: testUser,
+        pageCode: PagesCode.QualitiesList,
+      );
+
+      final initialSuggestions = _traitSuggestions(tester);
+      expect(initialSuggestions, hasLength(3));
+      expect(initialSuggestions.toSet(), hasLength(3));
+
+      await tester.tap(_refreshButton());
+      await tester.pumpAndSettle();
+      final refreshedSuggestions = _traitSuggestions(tester);
+      expect(refreshedSuggestions, isNot(equals(initialSuggestions)));
+      expect(refreshedSuggestions.toSet(), hasLength(3));
+
+      final selectedSuggestion = refreshedSuggestions.first;
+      final selectedRow = find.byWidgetPredicate(
+        (widget) =>
+            widget is PositiveTraitItemSug &&
+            widget.inputText == selectedSuggestion,
+      );
+      await tester.tap(
+        find.descendant(
+          of: selectedRow,
+          matching: find.byType(SuggestionAddButton),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(testUser.positiveTraits, contains(selectedSuggestion));
+      expect(_traitSuggestions(tester), isNot(contains(selectedSuggestion)));
+    },
+  );
+
+  testWidgets('refreshes gratitude suggestions with unique eligible values', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    final testUser = user(
+      thanks: {
+        'thanks': ['already saved'],
+        'dates': [_date(now, '09:00')],
+      },
+    );
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.GratitudeJournal,
+    );
+
+    final initialSuggestions = _thanksSuggestions(tester);
+    expect(initialSuggestions, hasLength(3));
+    expect(initialSuggestions.toSet(), hasLength(3));
+
+    await tester.tap(_refreshButton());
+    await tester.pumpAndSettle();
+    final refreshedSuggestions = _thanksSuggestions(tester);
+    expect(refreshedSuggestions, isNot(equals(initialSuggestions)));
+    expect(refreshedSuggestions.toSet(), hasLength(3));
+
+    final selectedSuggestion = refreshedSuggestions.first;
+    final selectedRow = find.byWidgetPredicate(
+      (widget) =>
+          widget is ThanksItemSuggested &&
+          widget.inputText == selectedSuggestion,
+    );
+    await tester.tap(
+      find.descendant(
+        of: selectedRow,
+        matching: find.byType(SuggestionAddButton),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(testUser.thanks['thanks'], contains(selectedSuggestion));
+    expect(_thanksSuggestions(tester), isNot(contains(selectedSuggestion)));
+  });
+}

--- a/test/MainPageHelpers/mainpage_list_order_test.dart
+++ b/test/MainPageHelpers/mainpage_list_order_test.dart
@@ -297,6 +297,24 @@ void main() {
     },
   );
 
+  testWidgets('refreshes qualities suggestions after an external update', (
+    tester,
+  ) async {
+    final testUser = user(traits: <String>[]);
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.QualitiesList,
+    );
+
+    final offeredSuggestion = _traitSuggestions(tester).first;
+    testUser.updatePositiveTraits([offeredSuggestion]);
+    await tester.pump();
+
+    expect(_traitSuggestions(tester), isNot(contains(offeredSuggestion)));
+  });
+
   testWidgets('refreshes gratitude suggestions with unique eligible values', (
     tester,
   ) async {
@@ -340,5 +358,103 @@ void main() {
 
     expect(testUser.thanks['thanks'], contains(selectedSuggestion));
     expect(_thanksSuggestions(tester), isNot(contains(selectedSuggestion)));
+  });
+
+  testWidgets('refreshes gratitude suggestions after an external update', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    final testUser = user();
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.GratitudeJournal,
+    );
+
+    final offeredSuggestion = _thanksSuggestions(tester).first;
+    testUser.updateThanks({
+      'thanks': [offeredSuggestion],
+      'dates': [_date(now, '09:00')],
+    });
+    await tester.pump();
+
+    expect(_thanksSuggestions(tester), isNot(contains(offeredSuggestion)));
+  });
+
+  testWidgets('handles gratitude dates that outnumber saved entries', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    final testUser = user(
+      thanks: {
+        'thanks': ['today'],
+        'dates': [_date(now, '09:00'), _date(now, '10:00')],
+      },
+    );
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.GratitudeJournal,
+    );
+
+    final rows = tester
+        .widgetList<MainpageListItemWidget>(find.byType(MainpageListItemWidget))
+        .toList();
+    expect(rows.map((row) => row.item), ['today']);
+    expect(_thanksSuggestions(tester), hasLength(3));
+    final selectedSuggestion = _thanksSuggestions(tester).first;
+    await tester.tap(
+      find.descendant(
+        of: find.byWidgetPredicate(
+          (widget) =>
+              widget is ThanksItemSuggested &&
+              widget.inputText == selectedSuggestion,
+        ),
+        matching: find.byType(SuggestionAddButton),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(testUser.thanks['thanks'], contains(selectedSuggestion));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('skips malformed gratitude dates without failing Home', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    final testUser = user(
+      thanks: {
+        'thanks': ['today', 'corrupt'],
+        'dates': [_date(now, '09:00'), 'bad'],
+      },
+    );
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.GratitudeJournal,
+    );
+
+    final rows = tester
+        .widgetList<MainpageListItemWidget>(find.byType(MainpageListItemWidget))
+        .toList();
+    expect(rows.map((row) => row.item), ['today']);
+    expect(_thanksSuggestions(tester), hasLength(3));
+    final selectedSuggestion = _thanksSuggestions(tester).first;
+    await tester.tap(
+      find.descendant(
+        of: find.byWidgetPredicate(
+          (widget) =>
+              widget is ThanksItemSuggested &&
+              widget.inputText == selectedSuggestion,
+        ),
+        matching: find.byType(SuggestionAddButton),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(testUser.thanks['thanks'], contains(selectedSuggestion));
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/pages/home_state_resilience_test.dart
+++ b/test/pages/home_state_resilience_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mazilon/MainPageHelpers/MainPageList/mainpage_list_widget.dart';
 import 'package:mazilon/global_enums.dart';
 import 'package:mazilon/pages/home.dart';
 import 'package:mazilon/util/Form/formPagePhoneModel.dart';
@@ -61,6 +62,33 @@ void main() {
     await tester.pump();
 
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Home places Gratitude Journal before Qualities List', (
+    tester,
+  ) async {
+    await pumpWithProviders(
+      tester,
+      Home(
+        phonePageData: _phoneData(),
+        changeCurrentIndex: (BuildContext context, PagesCode code) {},
+        changeLocale: (_) {},
+        openMainMenu: (_) {},
+      ),
+      userInformation: user,
+      surfaceSize: const Size(1024, 2400),
+    );
+
+    final listWidgets = tester.widgetList<ListWidget>(find.byType(ListWidget));
+
+    expect(listWidgets.map((widget) => widget.pageCode), [
+      PagesCode.GratitudeJournal,
+      PagesCode.QualitiesList,
+    ]);
+    expect(
+      tester.getTopLeft(find.byType(ListWidget).first).dy,
+      lessThan(tester.getTopLeft(find.byType(ListWidget).at(1)).dy),
+    );
   });
 
   test(


### PR DESCRIPTION
# User description
## Summary
- Render Gratitude Journal above Qualities List on Home.
- Render saved Home entries newest first, followed by **Show all**, then suggestions and the localized refresh control.
- Keep Home suggestion state private, distinct, refreshable, and synchronized after an item is added.
- Map each displayed Home row back to its exact persisted source index for correct edit/delete behavior with filtered or duplicate entries.

## Root cause
The Home preview placed random suggestions ahead of saved data and derived edit/delete indexes from display positions that no longer matched reversed or filtered persisted lists.

## Validation
- `dart format --output=none --set-exit-if-changed` (changed files)
- `flutter analyze`
- Focused Home/list widget tests
- `flutter test --no-pub` — 770 passed, 9 expected skips
- `git diff --check` and `git diff --cached --check`

Closes #185

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
editThanksState_("editThanksState"):::modified
refreshHomeSuggestions_("_refreshHomeSuggestions"):::added
editTraitsState_("editTraitsState"):::modified
eligibleSuggestions_("_eligibleSuggestions"):::added
selectHomeSuggestions_("_selectHomeSuggestions"):::added
todayThankYouIndexes_("_todayThankYouIndexes"):::added
sameOrder_("_sameOrder"):::added
INTL_DATEFORMAT_("INTL_DATEFORMAT"):::added
editThanksState_ -- "After saving thanks, refreshes suggestions using updated today-filtered entries." --> refreshHomeSuggestions_
editTraitsState_ -- "After updating traits, refreshes home suggestions from positive traits." --> refreshHomeSuggestions_
refreshHomeSuggestions_ -- "Computes candidate suggestions, excluding existing items for current page." --> eligibleSuggestions_
refreshHomeSuggestions_ -- "Shuffles eligible candidates and selects three; avoids identical ordering." --> selectHomeSuggestions_
eligibleSuggestions_ -- "Filters gratitude suggestions by excluding thank-yous written today." --> todayThankYouIndexes_
selectHomeSuggestions_ -- "_sameOrder compares previous and new selections to rotate duplicates." --> sameOrder_
todayThankYouIndexes_ -- "INTL_DATEFORMAT formats yyyy-MM-dd for date prefix matching." --> INTL_DATEFORMAT_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Reorder <code>Home</code> so <code>GratitudeJournal</code> appears above <code>QualitiesList</code>, and update <code>ListWidget</code> to render saved rows newest-first with suggestions and refresh controls after <code>ShowAllButton</code>. Map displayed rows back to their persisted indexes so <code>ListBodyWidget</code> actions edit and delete the correct gratitude or trait entry after filtering or duplicates.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/306?tool=ast&topic=Home+order>Home order</a>
        </td><td>Reorder <code>Home</code> so the gratitude section renders before the qualities section.<details><summary>Modified files (2)</summary><ul><li>lib/pages/home.dart</li>
<li>test/pages/home_state_resilience_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(home): reorder gra...</td><td>July 31, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Resolve remaining UX g...</td><td>June 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/306?tool=ast&topic=List+behavior>List behavior</a>
        </td><td>Refresh <code>ListWidget</code> suggestions privately, show saved items newest-first, and keep edit/delete actions aligned to persisted indexes for gratitude and traits rows.<details><summary>Modified files (4)</summary><ul><li>lib/MainPageHelpers/MainPageList/list_utils.dart</li>
<li>lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart</li>
<li>lib/util/Thanks/thanksItemSug.dart</li>
<li>test/MainPageHelpers/mainpage_list_order_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(home): harden grat...</td><td>July 31, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Fix Flutter analyzer i...</td><td>May 31, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/306?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>