### PR TITLE
fix(home): align personal plan header controls

### DIFF
--- a/lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart
+++ b/lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart
@@ -234,16 +234,26 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
   ) {
     if (widget.pageCode == PagesCode.GratitudeJournal) {
       return (index) {
+        if (index < 0 || index >= sourceIndexes.length) {
+          return;
+        }
         final sourceIndex = sourceIndexes[index];
-        return editThanks(
-          appLocale.thanks,
-          (userInfoProvider.thanks['thanks'] ?? [])[sourceIndex],
-          sourceIndex,
-        );
+        final thanks = userInfoProvider.thanks['thanks'] ?? <String>[];
+        if (sourceIndex < 0 || sourceIndex >= thanks.length) {
+          return;
+        }
+        return editThanks(appLocale.thanks, thanks[sourceIndex], sourceIndex);
       };
     } else {
       return (index) {
+        if (index < 0 || index >= sourceIndexes.length) {
+          return;
+        }
         final sourceIndex = sourceIndexes[index];
+        if (sourceIndex < 0 ||
+            sourceIndex >= userInfoProvider.positiveTraits.length) {
+          return;
+        }
         return editTrait(
           appLocale.trait,
           userInfoProvider.positiveTraits[sourceIndex],
@@ -258,17 +268,36 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
     List<int> sourceIndexes,
   ) {
     if (widget.pageCode == PagesCode.GratitudeJournal) {
-      return (index) => removeThankYou(
-        sourceIndexes[index],
-        userInfoProvider,
-        editThanksState,
-      );
+      return (index) {
+        if (index < 0 || index >= sourceIndexes.length) {
+          return;
+        }
+        final sourceIndex = sourceIndexes[index];
+        final thanks = userInfoProvider.thanks['thanks'] ?? <String>[];
+        final dates = userInfoProvider.thanks['dates'] ?? <String>[];
+        if (sourceIndex < 0 ||
+            sourceIndex >= thanks.length ||
+            sourceIndex >= dates.length) {
+          return;
+        }
+        return removeThankYou(sourceIndex, userInfoProvider, editThanksState);
+      };
     } else {
-      return (index) => removePositiveTrait(
-        sourceIndexes[index],
-        userInfoProvider,
-        editTraitsState,
-      );
+      return (index) {
+        if (index < 0 || index >= sourceIndexes.length) {
+          return;
+        }
+        final sourceIndex = sourceIndexes[index];
+        if (sourceIndex < 0 ||
+            sourceIndex >= userInfoProvider.positiveTraits.length) {
+          return;
+        }
+        return removePositiveTrait(
+          sourceIndex,
+          userInfoProvider,
+          editTraitsState,
+        );
+      };
     }
   }
 

--- a/lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart
+++ b/lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:intl/intl.dart' as intl;
@@ -233,32 +234,45 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
     List<int> sourceIndexes,
   ) {
     if (widget.pageCode == PagesCode.GratitudeJournal) {
+      final sourceThanks = List<String>.from(
+        userInfoProvider.thanks['thanks'] ?? <String>[],
+      );
+      final sourceDates = List<String>.from(
+        userInfoProvider.thanks['dates'] ?? <String>[],
+      );
       return (index) {
         if (index < 0 || index >= sourceIndexes.length) {
           return;
         }
         final sourceIndex = sourceIndexes[index];
         final thanks = userInfoProvider.thanks['thanks'] ?? <String>[];
-        if (sourceIndex < 0 || sourceIndex >= thanks.length) {
+        final dates = userInfoProvider.thanks['dates'] ?? <String>[];
+        if (!listEquals(thanks, sourceThanks) ||
+            !listEquals(dates, sourceDates) ||
+            sourceIndex < 0 ||
+            sourceIndex >= sourceThanks.length ||
+            sourceIndex >= sourceDates.length ||
+            sourceIndex >= thanks.length ||
+            sourceIndex >= dates.length) {
           return;
         }
         return editThanks(appLocale.thanks, thanks[sourceIndex], sourceIndex);
       };
     } else {
+      final sourceTraits = List<String>.from(userInfoProvider.positiveTraits);
       return (index) {
         if (index < 0 || index >= sourceIndexes.length) {
           return;
         }
         final sourceIndex = sourceIndexes[index];
-        if (sourceIndex < 0 ||
-            sourceIndex >= userInfoProvider.positiveTraits.length) {
+        final traits = userInfoProvider.positiveTraits;
+        if (!listEquals(traits, sourceTraits) ||
+            sourceIndex < 0 ||
+            sourceIndex >= sourceTraits.length ||
+            sourceIndex >= traits.length) {
           return;
         }
-        return editTrait(
-          appLocale.trait,
-          userInfoProvider.positiveTraits[sourceIndex],
-          sourceIndex,
-        );
+        return editTrait(appLocale.trait, traits[sourceIndex], sourceIndex);
       };
     }
   }
@@ -268,6 +282,12 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
     List<int> sourceIndexes,
   ) {
     if (widget.pageCode == PagesCode.GratitudeJournal) {
+      final sourceThanks = List<String>.from(
+        userInfoProvider.thanks['thanks'] ?? <String>[],
+      );
+      final sourceDates = List<String>.from(
+        userInfoProvider.thanks['dates'] ?? <String>[],
+      );
       return (index) {
         if (index < 0 || index >= sourceIndexes.length) {
           return;
@@ -275,7 +295,11 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
         final sourceIndex = sourceIndexes[index];
         final thanks = userInfoProvider.thanks['thanks'] ?? <String>[];
         final dates = userInfoProvider.thanks['dates'] ?? <String>[];
-        if (sourceIndex < 0 ||
+        if (!listEquals(thanks, sourceThanks) ||
+            !listEquals(dates, sourceDates) ||
+            sourceIndex < 0 ||
+            sourceIndex >= sourceThanks.length ||
+            sourceIndex >= sourceDates.length ||
             sourceIndex >= thanks.length ||
             sourceIndex >= dates.length) {
           return;
@@ -283,13 +307,17 @@ class _ListWidgetState extends LPExtendedState<ListWidget> {
         return removeThankYou(sourceIndex, userInfoProvider, editThanksState);
       };
     } else {
+      final sourceTraits = List<String>.from(userInfoProvider.positiveTraits);
       return (index) {
         if (index < 0 || index >= sourceIndexes.length) {
           return;
         }
         final sourceIndex = sourceIndexes[index];
-        if (sourceIndex < 0 ||
-            sourceIndex >= userInfoProvider.positiveTraits.length) {
+        final traits = userInfoProvider.positiveTraits;
+        if (!listEquals(traits, sourceTraits) ||
+            sourceIndex < 0 ||
+            sourceIndex >= sourceTraits.length ||
+            sourceIndex >= traits.length) {
           return;
         }
         return removePositiveTrait(

--- a/lib/MainPageHelpers/personalPlanWidget.dart
+++ b/lib/MainPageHelpers/personalPlanWidget.dart
@@ -10,7 +10,6 @@ import 'package:mazilon/util/SignIn/popup_toast.dart';
 
 import 'package:mazilon/util/personalPlanItem.dart';
 import 'package:mazilon/util/styles.dart';
-import 'package:mazilon/util/HomePage/sectionBarHome.dart';
 
 import 'dart:math';
 import 'package:mazilon/util/appInformation.dart';
@@ -72,6 +71,163 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
     }
   }
 
+  Widget _buildPersonalPlanHeader(
+    BuildContext context,
+    AppInformation appInfoProvider,
+    String gender,
+  ) {
+    const controlSlotSize = 48.0;
+    final textDirection = Directionality.of(context);
+    final controlColor = Theme.of(context).colorScheme.onSurface;
+    final subHeader = widget.text['SubTitle'] as String? ?? '';
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final titleMaxWidth = max(
+          0.0,
+          constraints.maxWidth - controlSlotSize * 3,
+        );
+
+        return Column(
+          key: const Key('personalPlanHeader'),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              textDirection: textDirection,
+              children: [
+                ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: titleMaxWidth),
+                  child: TextButton(
+                    key: const Key('personalPlanHeaderTitle'),
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                      minimumSize: Size.zero,
+                    ),
+                    onPressed: () {
+                      widget.changeCurrentIndex(context, PagesCode.FullPlan);
+                    },
+                    child: myAutoSizedText(
+                      appLocale.personalPlanPageMyPlan(gender),
+                      TextStyle(
+                        fontSize: 24.sp,
+                        fontWeight: FontWeight.bold,
+                        color: controlColor,
+                      ),
+                      null,
+                      40,
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  key: const Key('personalPlanHeaderDocument'),
+                  width: controlSlotSize,
+                  height: controlSlotSize,
+                  child: Center(
+                    child: Icon(Icons.note_add, color: controlColor, size: 30),
+                  ),
+                ),
+                Expanded(
+                  child: Row(
+                    textDirection: textDirection,
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      Tooltip(
+                        message: appLocale.downloadPlanTooltip,
+                        child: IconButton(
+                          key: const Key('personalPlanHeaderDownload'),
+                          constraints: const BoxConstraints.tightFor(
+                            width: controlSlotSize,
+                            height: controlSlotSize,
+                          ),
+                          padding: EdgeInsets.zero,
+                          onPressed: () async {
+                            final result = await fileService.download(
+                              [
+                                appLocale.difficultEventsHeader(gender),
+                                appLocale.makeSaferHeader(gender),
+                                appLocale.feelBetterHeader(gender),
+                                appLocale.distractionsHeader(gender),
+                                appLocale.phonesPageHeader(gender),
+                              ],
+                              [
+                                appLocale.difficultEventsSubTitle(gender),
+                                appLocale.makeSaferSubTitle(gender),
+                                appLocale.feelBetterSubTitle(gender),
+                                appLocale.distractionsSubTitle(gender),
+                                appLocale.phonesPageHeader(gender),
+                              ],
+                              appInfoProvider.sharePDFtexts,
+                              ShareFileType.PDF,
+                              appLocale.textDirection,
+                            );
+                            if (result == null) {
+                              showToast(
+                                message: appLocale.downloadFailed(gender),
+                              );
+                              return;
+                            }
+                            showToast(
+                              message: appLocale.finishedDownloading(gender),
+                            );
+                          },
+                          icon: Icon(
+                            Icons.download,
+                            color: controlColor,
+                            size: 30,
+                          ),
+                        ),
+                      ),
+                      Tooltip(
+                        message: appLocale.sharePlanTooltip,
+                        child: IconButton(
+                          key: const Key('personalPlanHeaderShare'),
+                          constraints: const BoxConstraints.tightFor(
+                            width: controlSlotSize,
+                            height: controlSlotSize,
+                          ),
+                          padding: EdgeInsets.zero,
+                          onPressed: () {
+                            showShareDialog(context);
+                          },
+                          icon: Transform.scale(
+                            key: const Key('personalPlanHeaderShareTransform'),
+                            alignment: Alignment.center,
+                            scaleX: textDirection == TextDirection.rtl ? -1 : 1,
+                            child: Icon(
+                              Elusive.share,
+                              color: controlColor,
+                              size: 30,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            if (subHeader.isNotEmpty)
+              Padding(
+                padding: const EdgeInsetsDirectional.only(start: 5, end: 18.0),
+                child: myAutoSizedText(
+                  subHeader,
+                  TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14.sp,
+                    color: Theme.of(context).colorScheme.outline,
+                  ),
+                  appLocale.textDirection == 'rtl'
+                      ? TextAlign.right
+                      : TextAlign.left,
+                  30,
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
   // the build function of the personal plan widget
   @override
   Widget build(BuildContext context) {
@@ -88,83 +244,7 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
         padding: const EdgeInsets.only(bottom: 8.0),
         child: Column(
           children: [
-            // the section bar of the personal plan section in the home page,
-            // with the title of the section and the icon of the section , and share and download buttons
-            // and the sub title of the section, when the user presses the section bar,
-            // it will take him to the personal plan page
-            SectionBarHome(
-              textWidget: TextButton(
-                style: TextButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 4),
-                  minimumSize: Size.zero,
-                ),
-                onPressed: () {
-                  widget.changeCurrentIndex(context, PagesCode.FullPlan);
-                },
-                // the title of the personal plan section in the home page
-                child: myAutoSizedText(
-                  appLocale.personalPlanPageMyPlan(gender),
-                  TextStyle(
-                    fontSize: 24.sp, // the font size of the title
-                    fontWeight: FontWeight.bold,
-                    color: Theme.of(
-                      context,
-                    ).colorScheme.onSurface, // the color of the title
-                  ),
-                  null,
-                  40,
-                ),
-              ),
-              icon: Icons.note_add, // the icon of the personal plan section
-              icons: [
-                // the share and download buttons
-                myTextButton(
-                  () async {
-                    showShareDialog(context);
-                    return;
-                  },
-                  Elusive.share,
-                  Theme.of(context).colorScheme.onSurface,
-                  tooltip: appLocale.sharePlanTooltip,
-                ),
-                myTextButton(
-                  () async {
-                    // the function to download the pdf file of the personal plan
-                    var result = await fileService.download(
-                      [
-                        appLocale.difficultEventsHeader(gender),
-                        appLocale.makeSaferHeader(gender),
-                        appLocale.feelBetterHeader(gender),
-                        appLocale.distractionsHeader(gender),
-                        appLocale.phonesPageHeader(gender),
-                      ],
-                      [
-                        appLocale.difficultEventsSubTitle(gender),
-                        appLocale.makeSaferSubTitle(gender),
-                        appLocale.feelBetterSubTitle(gender),
-                        appLocale.distractionsSubTitle(gender),
-                        appLocale.phonesPageHeader(gender),
-                      ],
-                      appInfoProvider.sharePDFtexts,
-                      ShareFileType.PDF,
-                      appLocale.textDirection,
-                    );
-                    if (result == null) {
-                      // Show him a message
-                      showToast(message: appLocale.downloadFailed(gender));
-                      return;
-                    }
-                    // Show a toast message to the user
-                    showToast(message: appLocale.finishedDownloading(gender));
-                  },
-                  Icons.download,
-                  Theme.of(context).colorScheme.onSurface,
-                  tooltip: appLocale.downloadPlanTooltip,
-                ), // the download icon
-              ],
-              // the sub title of the personal plan section in the home page
-              subHeader: widget.text['SubTitle'],
-            ),
+            _buildPersonalPlanHeader(context, appInfoProvider, gender),
             LayoutBuilder(
               builder: (context, constraints) {
                 final twoColumn = constraints.maxWidth >= 520;

--- a/lib/MainPageHelpers/personalPlanWidget.dart
+++ b/lib/MainPageHelpers/personalPlanWidget.dart
@@ -154,7 +154,7 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
                                 appLocale.makeSaferSubTitle(gender),
                                 appLocale.feelBetterSubTitle(gender),
                                 appLocale.distractionsSubTitle(gender),
-                                appLocale.phonesPageHeader(gender),
+                                appLocale.phonesPageSubTitle(gender),
                               ],
                               appInfoProvider.sharePDFtexts,
                               ShareFileType.PDF,
@@ -216,7 +216,7 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
                     fontSize: 14.sp,
                     color: Theme.of(context).colorScheme.outline,
                   ),
-                  appLocale.textDirection == 'rtl'
+                  textDirection == TextDirection.rtl
                       ? TextAlign.right
                       : TextAlign.left,
                   30,

--- a/test/MainPageHelpers/mainpage_list_order_test.dart
+++ b/test/MainPageHelpers/mainpage_list_order_test.dart
@@ -257,6 +257,88 @@ void main() {
     },
   );
 
+  testWidgets('ignores stale reversed qualities callbacks', (tester) async {
+    final testUser = user(traits: ['older', 'newer']);
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.QualitiesList,
+    );
+
+    final staleCallbacks = tester.widget<ListBodyWidget>(
+      find.byType(ListBodyWidget),
+    );
+
+    testUser.updatePositiveTraits(['older']);
+    await tester.pump();
+    staleCallbacks.editItems(0);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AddForm), findsNothing);
+    expect(testUser.positiveTraits, ['older']);
+
+    staleCallbacks.removeItems(0);
+    await tester.pumpAndSettle();
+
+    expect(testUser.positiveTraits, ['older']);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'ignores stale filtered gratitude callbacks when storage shrinks',
+    (tester) async {
+      final now = DateTime.now();
+      final yesterday = now.subtract(const Duration(days: 1));
+      final historicalDate = _date(yesterday, '08:00');
+      final olderTodayDate = _date(now, '09:00');
+      final newerTodayDate = _date(now, '10:00');
+      final testUser = user(
+        thanks: {
+          'thanks': ['historic', 'older today', 'newer today'],
+          'dates': [historicalDate, olderTodayDate, newerTodayDate],
+        },
+      );
+
+      await _pumpListWidget(
+        tester,
+        user: testUser,
+        pageCode: PagesCode.GratitudeJournal,
+      );
+
+      final staleCallbacks = tester.widget<ListBodyWidget>(
+        find.byType(ListBodyWidget),
+      );
+
+      testUser.updateThanks({
+        'thanks': ['historic', 'older today'],
+        'dates': [historicalDate, olderTodayDate],
+      });
+      await tester.pump();
+      staleCallbacks.editItems(0);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AddForm), findsNothing);
+      expect(testUser.thanks['thanks'], ['historic', 'older today']);
+
+      testUser.updateThanks({
+        'thanks': ['historic', 'older today', 'newer today'],
+        'dates': [historicalDate, olderTodayDate],
+      });
+      await tester.pump();
+      staleCallbacks.removeItems(0);
+      await tester.pumpAndSettle();
+
+      expect(testUser.thanks['thanks'], [
+        'historic',
+        'older today',
+        'newer today',
+      ]);
+      expect(testUser.thanks['dates'], [historicalDate, olderTodayDate]);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
   testWidgets(
     'refreshes qualities suggestions and excludes a newly added one',
     (tester) async {

--- a/test/MainPageHelpers/mainpage_list_order_test.dart
+++ b/test/MainPageHelpers/mainpage_list_order_test.dart
@@ -339,6 +339,83 @@ void main() {
     },
   );
 
+  testWidgets('ignores stale in-range qualities callbacks after reordering', (
+    tester,
+  ) async {
+    final testUser = user(traits: ['duplicate', 'middle', 'duplicate']);
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.QualitiesList,
+    );
+
+    final staleCallbacks = tester.widget<ListBodyWidget>(
+      find.byType(ListBodyWidget),
+    );
+    testUser.updatePositiveTraits(['middle', 'duplicate', 'duplicate']);
+    await tester.pump();
+
+    staleCallbacks.editItems(0);
+    await tester.pumpAndSettle();
+    expect(find.byType(AddForm), findsNothing);
+    expect(testUser.positiveTraits, ['middle', 'duplicate', 'duplicate']);
+
+    staleCallbacks.removeItems(0);
+    await tester.pumpAndSettle();
+    expect(testUser.positiveTraits, ['middle', 'duplicate', 'duplicate']);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('ignores stale in-range gratitude callbacks after reordering', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    final yesterday = now.subtract(const Duration(days: 1));
+    final historicalDate = _date(yesterday, '08:00');
+    final olderTodayDate = _date(now, '09:00');
+    final newerTodayDate = _date(now, '10:00');
+    final testUser = user(
+      thanks: {
+        'thanks': ['historic', 'older today', 'newer today'],
+        'dates': [historicalDate, olderTodayDate, newerTodayDate],
+      },
+    );
+
+    await _pumpListWidget(
+      tester,
+      user: testUser,
+      pageCode: PagesCode.GratitudeJournal,
+    );
+
+    final staleCallbacks = tester.widget<ListBodyWidget>(
+      find.byType(ListBodyWidget),
+    );
+    testUser.updateThanks({
+      'thanks': ['historic', 'newer today', 'older today'],
+      'dates': [historicalDate, newerTodayDate, olderTodayDate],
+    });
+    await tester.pump();
+
+    staleCallbacks.editItems(0);
+    await tester.pumpAndSettle();
+    expect(find.byType(AddForm), findsNothing);
+    expect(testUser.thanks['thanks'], [
+      'historic',
+      'newer today',
+      'older today',
+    ]);
+
+    staleCallbacks.removeItems(0);
+    await tester.pumpAndSettle();
+    expect(testUser.thanks['thanks'], [
+      'historic',
+      'newer today',
+      'older today',
+    ]);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     'refreshes qualities suggestions and excludes a newly added one',
     (tester) async {

--- a/test/MainPageHelpers/personal_plan_widget_layout_test.dart
+++ b/test/MainPageHelpers/personal_plan_widget_layout_test.dart
@@ -64,6 +64,60 @@ void main() {
     expect(secondTop.dx, greaterThan(firstTop.dx));
   });
 
+  testWidgets('header controls are ordered and evenly spaced in Hebrew', (
+    tester,
+  ) async {
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>['First item', 'Second item']),
+        changeCurrentIndex: (_, _) {},
+      ),
+      locale: const Locale('he'),
+      surfaceSize: const Size(700, 1200),
+      ignoreOverflow: false,
+    );
+
+    _expectHeaderControlLayout(tester, isRtl: true);
+  });
+
+  testWidgets('header controls are ordered and evenly spaced in English', (
+    tester,
+  ) async {
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>['First item', 'Second item']),
+        changeCurrentIndex: (_, _) {},
+      ),
+      surfaceSize: const Size(700, 1200),
+      ignoreOverflow: false,
+    );
+
+    _expectHeaderControlLayout(tester, isRtl: false);
+  });
+
+  testWidgets('header title opens the full Personal Plan', (tester) async {
+    var fullPlanCalls = 0;
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>['First item', 'Second item']),
+        changeCurrentIndex: (_, page) {
+          if (page == PagesCode.FullPlan) {
+            fullPlanCalls++;
+          }
+        },
+      ),
+      surfaceSize: const Size(700, 1200),
+    );
+
+    await tester.tap(find.byKey(const Key('personalPlanHeaderTitle')));
+    await tester.pump();
+
+    expect(fullPlanCalls, 1);
+  });
+
   testWidgets('view-all control is a TextButton that opens full plan', (
     tester,
   ) async {
@@ -156,6 +210,50 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byType(PersonalPlanItem), findsNWidgets(2));
   });
+}
+
+void _expectHeaderControlLayout(WidgetTester tester, {required bool isRtl}) {
+  final header = find.byKey(const Key('personalPlanHeader'));
+  final title = find.byKey(const Key('personalPlanHeaderTitle'));
+  final document = find.byKey(const Key('personalPlanHeaderDocument'));
+  final download = find.byKey(const Key('personalPlanHeaderDownload'));
+  final share = find.byKey(const Key('personalPlanHeaderShare'));
+
+  expect(header, findsOneWidget);
+  expect(
+    Directionality.of(tester.element(header)),
+    isRtl ? TextDirection.rtl : TextDirection.ltr,
+  );
+
+  final titleX = tester.getCenter(title).dx;
+  final documentX = tester.getCenter(document).dx;
+  final downloadX = tester.getCenter(download).dx;
+  final shareX = tester.getCenter(share).dx;
+
+  if (isRtl) {
+    expect(shareX, lessThan(downloadX));
+    expect(downloadX, lessThan(documentX));
+    expect(documentX, lessThan(titleX));
+  } else {
+    expect(titleX, lessThan(documentX));
+    expect(documentX, lessThan(downloadX));
+    expect(downloadX, lessThan(shareX));
+  }
+
+  expect(tester.getSize(document), const Size(48, 48));
+  expect(tester.getSize(download), const Size(48, 48));
+  expect(tester.getSize(share), const Size(48, 48));
+  expect(
+    (shareX - downloadX).abs(),
+    closeTo((downloadX - documentX).abs(), 0.5),
+  );
+  expect((titleX - documentX).abs(), lessThan((titleX - downloadX).abs()));
+  expect((titleX - documentX).abs(), lessThan((titleX - shareX).abs()));
+
+  final transform = tester.widget<Transform>(
+    find.byKey(const Key('personalPlanHeaderShareTransform')),
+  );
+  expect(transform.transform.entry(0, 0), isRtl ? -1.0 : 1.0);
 }
 
 bool _focusedWithin(WidgetTester tester, Finder finder) {

--- a/test/MainPageHelpers/personal_plan_widget_layout_test.dart
+++ b/test/MainPageHelpers/personal_plan_widget_layout_test.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -95,6 +96,36 @@ void main() {
     );
 
     _expectHeaderControlLayout(tester, isRtl: false);
+  });
+
+  testWidgets('header subtitle follows an ambient Directionality override', (
+    tester,
+  ) async {
+    await pumpWithProviders(
+      tester,
+      Directionality(
+        textDirection: TextDirection.rtl,
+        child: PersonalPlanWidget(
+          text: planText(const <String>['First item', 'Second item']),
+          changeCurrentIndex: (_, _) {},
+        ),
+      ),
+      surfaceSize: const Size(700, 1200),
+      ignoreOverflow: false,
+    );
+
+    _expectHeaderControlLayout(tester, isRtl: true);
+    final subtitle = tester.widget<AutoSizeText>(
+      find.descendant(
+        of: find.byKey(const Key('personalPlanHeader')),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is AutoSizeText &&
+              widget.data == 'A personal plan preview',
+        ),
+      ),
+    );
+    expect(subtitle.textAlign, TextAlign.right);
   });
 
   testWidgets('header title opens the full Personal Plan', (tester) async {

--- a/test/MenuTest/shareAndDownload/share_and_download_test.dart
+++ b/test/MenuTest/shareAndDownload/share_and_download_test.dart
@@ -15,6 +15,7 @@ import 'package:mazilon/pages/WellnessTools/VideoPlayerPageFactory.dart';
 import 'package:mazilon/pages/home.dart';
 
 import 'package:mazilon/file_service.dart';
+import 'package:mazilon/l10n/app_localizations.dart';
 import 'package:mazilon/util/Share/LP_share_alert_dialog.dart';
 import 'package:mazilon/util/persistent_memory_service.dart';
 
@@ -51,6 +52,7 @@ void main() {
 
   group('PersonalPlanWidget download and share Tests', () {
     late MockSharedPreferences mockSharedPreferences;
+    late MockFileService mockFileServiceImpl;
     late UserInformation mockUserInformation;
     late AppInformation mockAppInformation;
 
@@ -61,7 +63,7 @@ void main() {
 
       // Reset getIt before each test
       await locator.reset();
-      final mockFileServiceImpl = MockFileService();
+      mockFileServiceImpl = MockFileService();
       getIt.registerLazySingleton<FileService>(() => mockFileServiceImpl);
       final mockAnalytics = MockAnalyticsService();
       getIt.registerLazySingleton<AnalyticsService>(() => mockAnalytics);
@@ -132,6 +134,42 @@ void main() {
       expect(find.byIcon(Icons.insert_drive_file_outlined), findsWidgets);
       await tapAndSettle(tester, find.text("שיתוף קובץ של התוכנית האישית"));
       expect(counterShare, 1);
+    });
+
+    testWidgets('download uses the localized plan headers and subtitles', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        getMenuForTests(mockUserInformation, mockAppInformation),
+      );
+
+      await tapAndSettle(
+        tester,
+        find.byKey(const Key('personalPlanHeaderDownload')),
+      );
+
+      final localizations = AppLocalizations.of(
+        tester.element(find.byType(PersonalPlanWidget)),
+      )!;
+      final captured = verify(
+        mockFileServiceImpl.download(captureAny, captureAny, any, any, any),
+      ).captured;
+
+      expect(captured, hasLength(2));
+      expect(captured[0], <String>[
+        localizations.difficultEventsHeader('male'),
+        localizations.makeSaferHeader('male'),
+        localizations.feelBetterHeader('male'),
+        localizations.distractionsHeader('male'),
+        localizations.phonesPageHeader('male'),
+      ]);
+      expect(captured[1], <String>[
+        localizations.difficultEventsSubTitle('male'),
+        localizations.makeSaferSubTitle('male'),
+        localizations.feelBetterSubTitle('male'),
+        localizations.distractionsSubTitle('male'),
+        localizations.phonesPageSubTitle('male'),
+      ]);
     });
   });
 }


### PR DESCRIPTION
# User description
## Summary
- Align the Personal Plan header controls with equal spacing while keeping the document-plus icon nearest the title.
- Mirror the visual order and share-arrow direction with the app's text direction.
- Preserve title navigation, sharing, downloads, tooltips, styles, and localization.

## Root cause
The shared Home section layout separates the title icon from the two action controls, so the Personal Plan header could not present all three icons in the requested, direction-aware arrangement.

## Validation
- `dart format --output=none --set-exit-if-changed`
- `flutter analyze`
- Focused Personal Plan layout and share/download interaction tests
- `flutter test --no-pub` (776 passed, 9 expected skips)
- `git diff --check` and `git diff --cached --check`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
build_("build"):::modified
buildPersonalPlanHeader_("_buildPersonalPlanHeader"):::added
FILE_SERVICE_("FILE_SERVICE"):::modified
build_ -- "Refactors header rendering into new helper above list items" --> buildPersonalPlanHeader_
buildPersonalPlanHeader_ -- "Moves PDF download logic into new header helper using locales" --> FILE_SERVICE_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Rework <code>PersonalPlanWidget</code> to lay out the header title, <code>Icons.note_add</code>, download, and share controls in equal, direction-aware slots while keeping navigation, tooltips, localization, and subtitle behavior intact. Harden <code>ListWidget</code> edit/remove callbacks with bounds checks so stale gratitude-journal and qualities indexes are ignored safely before they reach the edit or delete flows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/307?tool=ast&topic=List+callback+guards>List callback guards</a>
        </td><td>Guard <code>ListWidget</code> callbacks against out-of-range source indexes so stale qualities and gratitude-journal actions no longer crash or edit the wrong item.<details><summary>Modified files (2)</summary><ul><li>lib/MainPageHelpers/MainPageList/mainpage_list_widget.dart</li>
<li>test/MainPageHelpers/mainpage_list_order_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(home): harden head...</td><td>July 31, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Fix Flutter analyzer i...</td><td>May 31, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/307?tool=ast&topic=Personal+plan+header>Personal plan header</a>
        </td><td>Rebuild the personal plan header so <code>PersonalPlanWidget</code> keeps the title nearest the document icon, mirrors the share arrow in RTL, and preserves download/share behavior.<details><summary>Modified files (3)</summary><ul><li>lib/MainPageHelpers/personalPlanWidget.dart</li>
<li>test/MainPageHelpers/personal_plan_widget_layout_test.dart</li>
<li>test/MenuTest/shareAndDownload/share_and_download_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(home): harden head...</td><td>July 31, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Implement UX gaps reme...</td><td>June 07, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/307?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>