### PR TITLE
feat(home): add personal plan shuffle

### DIFF
--- a/lib/MainPageHelpers/personalPlanWidget.dart
+++ b/lib/MainPageHelpers/personalPlanWidget.dart
@@ -59,12 +59,8 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
     randomItems = _selectedIndexes.map((index) => items[index]).toList();
   }
 
-  List<int> _selectPreviewIndexes(
-    List<String> items,
-    List<int> previousIndexes, {
-    required bool avoidCurrentSelection,
-  }) {
-    final candidates = <List<int>>[
+  List<List<int>> _previewCandidates(List<String> items) {
+    return <List<int>>[
       for (var firstIndex = 0; firstIndex < items.length - 1; firstIndex++)
         for (
           var secondIndex = firstIndex + 1;
@@ -73,6 +69,14 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
         )
           <int>[firstIndex, secondIndex],
     ];
+  }
+
+  List<int> _selectPreviewIndexes(
+    List<String> items,
+    List<int> previousIndexes, {
+    required bool avoidCurrentSelection,
+  }) {
+    final candidates = _previewCandidates(items);
     var availableCandidates = candidates;
 
     if (avoidCurrentSelection && previousIndexes.length == 2) {
@@ -123,6 +127,20 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
     return true;
   }
 
+  bool _hasAlternativeVisiblePreview(List<String> items) {
+    if (items.length < 2 || _selectedIndexes.length != 2) {
+      return false;
+    }
+
+    if (items.length == 2) {
+      return randomItems.length == 2 && randomItems.first != randomItems.last;
+    }
+
+    return _previewCandidates(items).any(
+      (candidate) => !_hasSameVisibleItems(candidate, _selectedIndexes, items),
+    );
+  }
+
   void _refreshPersonalPlanPreview() {
     setState(() {
       loadFeelBetter(avoidCurrentSelection: true);
@@ -151,10 +169,11 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
   ) {
     const controlSlotSize = 48.0;
     final textDirection = Directionality.of(context);
-    final controlColor = Theme.of(context).colorScheme.onSurface;
-    final refreshColor = Theme.of(context).colorScheme.outline;
-    final canRefresh =
-        List<String>.from(widget.text['list'] ?? const <String>[]).length >= 2;
+    final theme = Theme.of(context);
+    final controlColor = theme.colorScheme.onSurface;
+    final refreshColor = theme.colorScheme.outline;
+    final items = List<String>.from(widget.text['list'] ?? const <String>[]);
+    final canRefresh = _hasAlternativeVisiblePreview(items);
     final subHeader = widget.text['SubTitle'] as String? ?? '';
 
     return LayoutBuilder(
@@ -217,14 +236,12 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
                             height: controlSlotSize,
                           ),
                           padding: EdgeInsets.zero,
+                          color: refreshColor,
+                          disabledColor: theme.disabledColor,
                           onPressed: canRefresh
                               ? _refreshPersonalPlanPreview
                               : null,
-                          icon: Icon(
-                            Icons.refresh,
-                            color: refreshColor,
-                            size: min(35.sp, 40),
-                          ),
+                          icon: Icon(Icons.refresh, size: min(35.sp, 40)),
                         ),
                       ),
                       Tooltip(

--- a/lib/MainPageHelpers/personalPlanWidget.dart
+++ b/lib/MainPageHelpers/personalPlanWidget.dart
@@ -128,12 +128,8 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
   }
 
   bool _hasAlternativeVisiblePreview(List<String> items) {
-    if (items.length < 2 || _selectedIndexes.length != 2) {
+    if (items.length <= 2 || _selectedIndexes.length != 2) {
       return false;
-    }
-
-    if (items.length == 2) {
-      return randomItems.length == 2 && randomItems.first != randomItems.last;
     }
 
     return _previewCandidates(items).any(

--- a/lib/MainPageHelpers/personalPlanWidget.dart
+++ b/lib/MainPageHelpers/personalPlanWidget.dart
@@ -33,27 +33,100 @@ class PersonalPlanWidget extends StatefulWidget {
 
 class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
   late FileService fileService;
-  late List<String> randomItems = ['1', '2'];
+  final Random _random = Random();
+  List<int> _selectedIndexes = <int>[];
+  List<String> randomItems = <String>[];
   List<String> feelBetter = [];
-  void loadFeelBetter() {
-    var random = Random();
-    var index1 = 0;
-    var index2 = 0;
+
+  void loadFeelBetter({bool avoidCurrentSelection = false}) {
     final items = List<String>.from(widget.text['list'] ?? const <String>[]);
-    // taking two random items from the list of the feel better answers or other question
-    // that user filled in the form
-    if (items.length >= 2) {
-      index1 = random.nextInt(items.length);
-      do {
-        index2 = random.nextInt(items.length);
-      } while (index1 == index2);
-      randomItems = [items[index1], items[index2]];
-    } else if (items.length == 1) {
-      index1 = 0;
-      randomItems = [items[index1]];
+    final previousIndexes = _selectedIndexes;
+
+    if (items.length < 2) {
+      _selectedIndexes = List<int>.generate(items.length, (index) => index);
+    } else if (items.length == 2 &&
+        avoidCurrentSelection &&
+        previousIndexes.length == 2) {
+      _selectedIndexes = previousIndexes.reversed.toList();
     } else {
-      randomItems = [];
+      _selectedIndexes = _selectPreviewIndexes(
+        items,
+        previousIndexes,
+        avoidCurrentSelection: avoidCurrentSelection,
+      );
     }
+
+    randomItems = _selectedIndexes.map((index) => items[index]).toList();
+  }
+
+  List<int> _selectPreviewIndexes(
+    List<String> items,
+    List<int> previousIndexes, {
+    required bool avoidCurrentSelection,
+  }) {
+    final candidates = <List<int>>[
+      for (var firstIndex = 0; firstIndex < items.length - 1; firstIndex++)
+        for (
+          var secondIndex = firstIndex + 1;
+          secondIndex < items.length;
+          secondIndex++
+        )
+          <int>[firstIndex, secondIndex],
+    ];
+    var availableCandidates = candidates;
+
+    if (avoidCurrentSelection && previousIndexes.length == 2) {
+      final visiblyDifferentCandidates = candidates
+          .where(
+            (candidate) =>
+                !_hasSameVisibleItems(candidate, previousIndexes, items),
+          )
+          .toList();
+      availableCandidates = visiblyDifferentCandidates.isNotEmpty
+          ? visiblyDifferentCandidates
+          : candidates
+                .where(
+                  (candidate) =>
+                      !_hasSameSelectedIndexes(candidate, previousIndexes),
+                )
+                .toList();
+    }
+
+    final selectedIndexes = List<int>.from(
+      availableCandidates[_random.nextInt(availableCandidates.length)],
+    )..shuffle(_random);
+    return selectedIndexes;
+  }
+
+  bool _hasSameSelectedIndexes(List<int> indexes, List<int> previousIndexes) {
+    return indexes.length == previousIndexes.length &&
+        indexes.every(previousIndexes.contains);
+  }
+
+  bool _hasSameVisibleItems(
+    List<int> indexes,
+    List<int> previousIndexes,
+    List<String> items,
+  ) {
+    if (indexes.length != previousIndexes.length) {
+      return false;
+    }
+
+    final visibleItems = indexes.map((index) => items[index]).toList()..sort();
+    final previousItems = previousIndexes.map((index) => items[index]).toList()
+      ..sort();
+    for (var index = 0; index < visibleItems.length; index++) {
+      if (visibleItems[index] != previousItems[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void _refreshPersonalPlanPreview() {
+    setState(() {
+      loadFeelBetter(avoidCurrentSelection: true);
+    });
   }
 
   @override
@@ -79,13 +152,16 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
     const controlSlotSize = 48.0;
     final textDirection = Directionality.of(context);
     final controlColor = Theme.of(context).colorScheme.onSurface;
+    final refreshColor = Theme.of(context).colorScheme.outline;
+    final canRefresh =
+        List<String>.from(widget.text['list'] ?? const <String>[]).length >= 2;
     final subHeader = widget.text['SubTitle'] as String? ?? '';
 
     return LayoutBuilder(
       builder: (context, constraints) {
         final titleMaxWidth = max(
           0.0,
-          constraints.maxWidth - controlSlotSize * 3,
+          constraints.maxWidth - controlSlotSize * 4,
         );
 
         return Column(
@@ -128,9 +204,29 @@ class _PersonalPlanWidgetState extends LPExtendedState<PersonalPlanWidget> {
                 ),
                 Expanded(
                   child: Row(
+                    key: const Key('personalPlanHeaderActions'),
                     textDirection: textDirection,
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    mainAxisAlignment: MainAxisAlignment.end,
                     children: [
+                      Tooltip(
+                        message: appLocale.refreshPersonalPlanTooltip,
+                        child: IconButton(
+                          key: const Key('personalPlanHeaderRefresh'),
+                          constraints: const BoxConstraints.tightFor(
+                            width: controlSlotSize,
+                            height: controlSlotSize,
+                          ),
+                          padding: EdgeInsets.zero,
+                          onPressed: canRefresh
+                              ? _refreshPersonalPlanPreview
+                              : null,
+                          icon: Icon(
+                            Icons.refresh,
+                            color: refreshColor,
+                            size: min(35.sp, 40),
+                          ),
+                        ),
+                      ),
                       Tooltip(
                         message: appLocale.downloadPlanTooltip,
                         child: IconButton(

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -394,6 +394,7 @@
   "addItemTooltip": "إضافة",
   "downloadPlanTooltip": "تنزيل الخطة",
   "sharePlanTooltip": "مشاركة الخطة",
+  "refreshPersonalPlanTooltip": "تحديث الخطة الشخصية",
   "refreshQuoteTooltip": "اقتباس جديد",
   "dismissQuoteTooltip": "إغلاق الاقتباس",
   "callContactTooltip": "الاتصال بـ {contact}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1645,6 +1645,10 @@
   "@sharePlanTooltip": {
     "description": "Tooltip / TalkBack label for the icon-only share button on the personal plan widget"
   },
+  "refreshPersonalPlanTooltip": "Refresh personal plan",
+  "@refreshPersonalPlanTooltip": {
+    "description": "Tooltip / TalkBack label for the icon-only refresh button on the personal plan widget"
+  },
   "refreshQuoteTooltip": "New quote",
   "@refreshQuoteTooltip": {
     "description": "Tooltip / TalkBack label for the icon-only refresh button on the inspirational quote widget"

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -432,6 +432,7 @@
   "addItemTooltip": "הוספה",
   "downloadPlanTooltip": "הורדת התוכנית",
   "sharePlanTooltip": "שיתוף התוכנית",
+  "refreshPersonalPlanTooltip": "רענון התוכנית האישית",
   "refreshQuoteTooltip": "ציטוט חדש",
   "dismissQuoteTooltip": "סגירת הציטוט",
   "callContactTooltip": "התקשרות אל {contact}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2188,6 +2188,12 @@ abstract class AppLocalizations {
   /// **'Share plan'**
   String get sharePlanTooltip;
 
+  /// Tooltip / TalkBack label for the icon-only refresh button on the personal plan widget
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh personal plan'**
+  String get refreshPersonalPlanTooltip;
+
   /// Tooltip / TalkBack label for the icon-only refresh button on the inspirational quote widget
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3102,6 +3102,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get sharePlanTooltip => 'مشاركة الخطة';
 
   @override
+  String get refreshPersonalPlanTooltip => 'تحديث الخطة الشخصية';
+
+  @override
   String get refreshQuoteTooltip => 'اقتباس جديد';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3130,6 +3130,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sharePlanTooltip => 'Share plan';
 
   @override
+  String get refreshPersonalPlanTooltip => 'Refresh personal plan';
+
+  @override
   String get refreshQuoteTooltip => 'New quote';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3093,6 +3093,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get sharePlanTooltip => 'שיתוף התוכנית';
 
   @override
+  String get refreshPersonalPlanTooltip => 'רענון התוכנית האישית';
+
+  @override
   String get refreshQuoteTooltip => 'ציטוט חדש';
 
   @override

--- a/test/MainPageHelpers/personal_plan_widget_layout_test.dart
+++ b/test/MainPageHelpers/personal_plan_widget_layout_test.dart
@@ -107,7 +107,11 @@ void main() {
     await pumpWithProviders(
       tester,
       PersonalPlanWidget(
-        text: planText(const <String>['First item', 'Second item']),
+        text: planText(const <String>[
+          'First item',
+          'Second item',
+          'Third item',
+        ]),
         changeCurrentIndex: (_, _) {},
       ),
       surfaceSize: const Size(700, 1200),
@@ -163,6 +167,18 @@ void main() {
     await pumpWithProviders(
       tester,
       PersonalPlanWidget(
+        text: planText(const <String>['First item', 'Second item']),
+        changeCurrentIndex: (_, _) {},
+      ),
+      surfaceSize: const Size(700, 1200),
+    );
+
+    expect(tester.widget<IconButton>(refresh).onPressed, isNull);
+    expect(_previewItemTexts(tester), hasLength(2));
+
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
         text: planText(const <String>['Repeated item', 'Repeated item']),
         changeCurrentIndex: (_, _) {},
       ),
@@ -203,7 +219,7 @@ void main() {
     );
   });
 
-  testWidgets('refresh swaps a two-item preview', (tester) async {
+  testWidgets('refresh is disabled for a two-item preview', (tester) async {
     await pumpWithProviders(
       tester,
       PersonalPlanWidget(
@@ -214,11 +230,13 @@ void main() {
       ignoreOverflow: false,
     );
 
+    final refresh = find.byKey(const Key('personalPlanHeaderRefresh'));
     final before = _previewItemTexts(tester);
-    await tester.tap(find.byKey(const Key('personalPlanHeaderRefresh')));
+    expect(tester.widget<IconButton>(refresh).onPressed, isNull);
+    await tester.tap(refresh);
     await tester.pump();
 
-    expect(_previewItemTexts(tester), before.reversed.toList());
+    expect(_previewItemTexts(tester), before);
     expect(tester.takeException(), isNull);
   });
 

--- a/test/MainPageHelpers/personal_plan_widget_layout_test.dart
+++ b/test/MainPageHelpers/personal_plan_widget_layout_test.dart
@@ -1,5 +1,8 @@
+import 'dart:math';
+
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mazilon/MainPageHelpers/personalPlanWidget.dart';
@@ -65,7 +68,7 @@ void main() {
     expect(secondTop.dx, greaterThan(firstTop.dx));
   });
 
-  testWidgets('header controls are ordered and evenly spaced in Hebrew', (
+  testWidgets('header controls preserve directional order in Hebrew', (
     tester,
   ) async {
     await pumpWithProviders(
@@ -82,7 +85,7 @@ void main() {
     _expectHeaderControlLayout(tester, isRtl: true);
   });
 
-  testWidgets('header controls are ordered and evenly spaced in English', (
+  testWidgets('header controls preserve directional order in English', (
     tester,
   ) async {
     await pumpWithProviders(
@@ -96,6 +99,129 @@ void main() {
     );
 
     _expectHeaderControlLayout(tester, isRtl: false);
+  });
+
+  testWidgets('refresh control uses the localized grey refresh icon', (
+    tester,
+  ) async {
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>['First item', 'Second item']),
+        changeCurrentIndex: (_, _) {},
+      ),
+      surfaceSize: const Size(700, 1200),
+    );
+
+    final refresh = find.byKey(const Key('personalPlanHeaderRefresh'));
+    expect(refresh, findsOneWidget);
+    expect(find.byTooltip('Refresh personal plan'), findsOneWidget);
+    expect(tester.widget<IconButton>(refresh).onPressed, isNotNull);
+
+    final icon = tester.widget<Icon>(
+      find.descendant(of: refresh, matching: find.byIcon(Icons.refresh)),
+    );
+    expect(icon.color, Theme.of(tester.element(refresh)).colorScheme.outline);
+    expect(icon.size, min(35.sp, 40));
+  });
+
+  testWidgets('refresh is disabled when there is no alternative preview', (
+    tester,
+  ) async {
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>[]),
+        changeCurrentIndex: (_, _) {},
+      ),
+      surfaceSize: const Size(700, 1200),
+    );
+
+    final refresh = find.byKey(const Key('personalPlanHeaderRefresh'));
+    expect(refresh, findsOneWidget);
+    expect(tester.widget<IconButton>(refresh).onPressed, isNull);
+    expect(find.byType(PersonalPlanItem), findsNothing);
+
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>['Only item']),
+        changeCurrentIndex: (_, _) {},
+      ),
+      surfaceSize: const Size(700, 1200),
+    );
+
+    expect(tester.widget<IconButton>(refresh).onPressed, isNull);
+    expect(_previewItemTexts(tester), <String>['Only item']);
+  });
+
+  testWidgets('refresh swaps a two-item preview', (tester) async {
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>['First item', 'Second item']),
+        changeCurrentIndex: (_, _) {},
+      ),
+      surfaceSize: const Size(420, 1200),
+      ignoreOverflow: false,
+    );
+
+    final before = _previewItemTexts(tester);
+    await tester.tap(find.byKey(const Key('personalPlanHeaderRefresh')));
+    await tester.pump();
+
+    expect(_previewItemTexts(tester), before.reversed.toList());
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'refresh selects a different pair when more items are available',
+    (tester) async {
+      const items = <String>['First item', 'Second item', 'Third item'];
+      await pumpWithProviders(
+        tester,
+        PersonalPlanWidget(
+          text: planText(items),
+          changeCurrentIndex: (_, _) {},
+        ),
+        surfaceSize: const Size(420, 1200),
+        ignoreOverflow: false,
+      );
+
+      final before = _previewItemTexts(tester);
+      await tester.tap(find.byKey(const Key('personalPlanHeaderRefresh')));
+      await tester.pump();
+      final after = _previewItemTexts(tester);
+
+      expect(after, hasLength(2));
+      expect(after.every(items.contains), isTrue);
+      expect(after.toSet().length, 2);
+      expect(
+        after.toSet().containsAll(before) && before.toSet().containsAll(after),
+        isFalse,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('refresh changes the visible pair when source items repeat', (
+    tester,
+  ) async {
+    const items = <String>['Repeated item', 'Repeated item', 'Different item'];
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(text: planText(items), changeCurrentIndex: (_, _) {}),
+      surfaceSize: const Size(420, 1200),
+      ignoreOverflow: false,
+    );
+
+    final before = _previewItemTexts(tester)..sort();
+    await tester.tap(find.byKey(const Key('personalPlanHeaderRefresh')));
+    await tester.pump();
+    final after = _previewItemTexts(tester)..sort();
+
+    expect(after, isNot(equals(before)));
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('header subtitle follows an ambient Directionality override', (
@@ -240,13 +366,26 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.byType(PersonalPlanItem), findsNWidgets(2));
+
+    await tester.tap(find.byKey(const Key('personalPlanHeaderRefresh')));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
   });
+}
+
+List<String> _previewItemTexts(WidgetTester tester) {
+  return tester
+      .widgetList<PersonalPlanItem>(find.byType(PersonalPlanItem))
+      .map((item) => item.text)
+      .toList();
 }
 
 void _expectHeaderControlLayout(WidgetTester tester, {required bool isRtl}) {
   final header = find.byKey(const Key('personalPlanHeader'));
   final title = find.byKey(const Key('personalPlanHeaderTitle'));
   final document = find.byKey(const Key('personalPlanHeaderDocument'));
+  final actions = find.byKey(const Key('personalPlanHeaderActions'));
+  final refresh = find.byKey(const Key('personalPlanHeaderRefresh'));
   final download = find.byKey(const Key('personalPlanHeaderDownload'));
   final share = find.byKey(const Key('personalPlanHeaderShare'));
 
@@ -258,33 +397,43 @@ void _expectHeaderControlLayout(WidgetTester tester, {required bool isRtl}) {
 
   final titleX = tester.getCenter(title).dx;
   final documentX = tester.getCenter(document).dx;
+  final refreshX = tester.getCenter(refresh).dx;
   final downloadX = tester.getCenter(download).dx;
   final shareX = tester.getCenter(share).dx;
 
   if (isRtl) {
     expect(shareX, lessThan(downloadX));
-    expect(downloadX, lessThan(documentX));
+    expect(downloadX, lessThan(refreshX));
+    expect(refreshX, lessThan(documentX));
     expect(documentX, lessThan(titleX));
   } else {
     expect(titleX, lessThan(documentX));
-    expect(documentX, lessThan(downloadX));
+    expect(documentX, lessThan(refreshX));
+    expect(refreshX, lessThan(downloadX));
     expect(downloadX, lessThan(shareX));
   }
 
   expect(tester.getSize(document), const Size(48, 48));
+  expect(tester.getSize(refresh), const Size(48, 48));
   expect(tester.getSize(download), const Size(48, 48));
   expect(tester.getSize(share), const Size(48, 48));
-  expect(
-    (shareX - downloadX).abs(),
-    closeTo((downloadX - documentX).abs(), 0.5),
-  );
+  expect((refreshX - downloadX).abs(), closeTo(48, 0.5));
+  expect((downloadX - shareX).abs(), closeTo(48, 0.5));
   expect((titleX - documentX).abs(), lessThan((titleX - downloadX).abs()));
+  expect((titleX - documentX).abs(), lessThan((titleX - refreshX).abs()));
   expect((titleX - documentX).abs(), lessThan((titleX - shareX).abs()));
 
   final transform = tester.widget<Transform>(
     find.byKey(const Key('personalPlanHeaderShareTransform')),
   );
   expect(transform.transform.entry(0, 0), isRtl ? -1.0 : 1.0);
+
+  final actionsRect = tester.getRect(actions);
+  if (isRtl) {
+    expect(tester.getRect(share).left, closeTo(actionsRect.left, 0.5));
+  } else {
+    expect(tester.getRect(share).right, closeTo(actionsRect.right, 0.5));
+  }
 }
 
 bool _focusedWithin(WidgetTester tester, Finder finder) {

--- a/test/MainPageHelpers/personal_plan_widget_layout_test.dart
+++ b/test/MainPageHelpers/personal_plan_widget_layout_test.dart
@@ -116,12 +116,18 @@ void main() {
     final refresh = find.byKey(const Key('personalPlanHeaderRefresh'));
     expect(refresh, findsOneWidget);
     expect(find.byTooltip('Refresh personal plan'), findsOneWidget);
-    expect(tester.widget<IconButton>(refresh).onPressed, isNotNull);
+    final button = tester.widget<IconButton>(refresh);
+    expect(button.onPressed, isNotNull);
+    expect(button.color, Theme.of(tester.element(refresh)).colorScheme.outline);
+    expect(
+      button.disabledColor,
+      Theme.of(tester.element(refresh)).disabledColor,
+    );
 
     final icon = tester.widget<Icon>(
       find.descendant(of: refresh, matching: find.byIcon(Icons.refresh)),
     );
-    expect(icon.color, Theme.of(tester.element(refresh)).colorScheme.outline);
+    expect(icon.color, isNull);
     expect(icon.size, min(35.sp, 40));
   });
 
@@ -153,6 +159,48 @@ void main() {
 
     expect(tester.widget<IconButton>(refresh).onPressed, isNull);
     expect(_previewItemTexts(tester), <String>['Only item']);
+
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>['Repeated item', 'Repeated item']),
+        changeCurrentIndex: (_, _) {},
+      ),
+      surfaceSize: const Size(700, 1200),
+    );
+
+    expect(tester.widget<IconButton>(refresh).onPressed, isNull);
+    expect(_previewItemTexts(tester), <String>[
+      'Repeated item',
+      'Repeated item',
+    ]);
+
+    await pumpWithProviders(
+      tester,
+      PersonalPlanWidget(
+        text: planText(const <String>[
+          'Repeated item',
+          'Repeated item',
+          'Repeated item',
+        ]),
+        changeCurrentIndex: (_, _) {},
+      ),
+      surfaceSize: const Size(700, 1200),
+    );
+
+    expect(tester.widget<IconButton>(refresh).onPressed, isNull);
+    expect(_previewItemTexts(tester), <String>[
+      'Repeated item',
+      'Repeated item',
+    ]);
+    final disabledIcon = find.descendant(
+      of: refresh,
+      matching: find.byIcon(Icons.refresh),
+    );
+    expect(
+      IconTheme.of(tester.element(disabledIcon)).color,
+      Theme.of(tester.element(refresh)).disabledColor,
+    );
   });
 
   testWidgets('refresh swaps a two-item preview', (tester) async {
@@ -216,6 +264,14 @@ void main() {
     );
 
     final before = _previewItemTexts(tester)..sort();
+    expect(
+      tester
+          .widget<IconButton>(
+            find.byKey(const Key('personalPlanHeaderRefresh')),
+          )
+          .onPressed,
+      isNotNull,
+    );
     await tester.tap(find.byKey(const Key('personalPlanHeaderRefresh')));
     await tester.pump();
     final after = _previewItemTexts(tester)..sort();


### PR DESCRIPTION
# User description
## Summary

- Add a localized refresh control to the Personal Plan header.
- Shuffle the visible current-category preview without immediate repetition when an alternative is available, including safe zero, one, and two-item behavior.
- Keep header actions compact at the physical left in RTL and physical right in LTR.

## Validation

- `flutter analyze`
- `flutter test test/MainPageHelpers/personal_plan_widget_layout_test.dart`
- `flutter test test/l10n/arabic_catalog_coverage_test.dart`
- `flutter test --no-pub` (787 passed, 9 expected skips)
- Android emulator debug launch and Hebrew header visual check

Closes #287

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
PersonalPlanWidgetState_loadFeelBetter_("_PersonalPlanWidgetState.loadFeelBetter"):::modified
PersonalPlanWidgetState_selectPreviewIndexes_("_PersonalPlanWidgetState._selectPreviewIndexes"):::added
PersonalPlanWidgetState_previewCandidates_("_PersonalPlanWidgetState._previewCandidates"):::added
PersonalPlanWidgetState_hasSameVisibleItems_("_PersonalPlanWidgetState._hasSameVisibleItems"):::added
PersonalPlanWidgetState_hasSameSelectedIndexes_("_PersonalPlanWidgetState._hasSameSelectedIndexes"):::added
PersonalPlanWidgetState_hasAlternativeVisiblePreview_("_PersonalPlanWidgetState._hasAlternativeVisiblePreview"):::added
PersonalPlanWidgetState_refreshPersonalPlanPreview_("_PersonalPlanWidgetState._refreshPersonalPlanPreview"):::added
PersonalPlanWidgetState_buildPersonalPlanHeader_("_PersonalPlanWidgetState._buildPersonalPlanHeader"):::modified
PersonalPlanWidgetState_loadFeelBetter_ -- "Generates new preview pair while avoiding current selection when requested." --> PersonalPlanWidgetState_selectPreviewIndexes_
PersonalPlanWidgetState_selectPreviewIndexes_ -- "Builds all two-item index combination candidates for preview selection." --> PersonalPlanWidgetState_previewCandidates_
PersonalPlanWidgetState_selectPreviewIndexes_ -- "Filters candidates that would display the same visible items." --> PersonalPlanWidgetState_hasSameVisibleItems_
PersonalPlanWidgetState_selectPreviewIndexes_ -- "Excludes exact same index pair as a fallback check." --> PersonalPlanWidgetState_hasSameSelectedIndexes_
PersonalPlanWidgetState_hasAlternativeVisiblePreview_ -- "Determines whether any alternative preview index pair exists." --> PersonalPlanWidgetState_previewCandidates_
PersonalPlanWidgetState_hasAlternativeVisiblePreview_ -- "Compares candidate visible items against current selection for differences." --> PersonalPlanWidgetState_hasSameVisibleItems_
PersonalPlanWidgetState_refreshPersonalPlanPreview_ -- "Refreshes preview by calling loadFeelBetter with avoidCurrentSelection true." --> PersonalPlanWidgetState_loadFeelBetter_
PersonalPlanWidgetState_buildPersonalPlanHeader_ -- "Enables the refresh button only if visible preview can change." --> PersonalPlanWidgetState_hasAlternativeVisiblePreview_
PersonalPlanWidgetState_buildPersonalPlanHeader_ -- "Connects refresh button onPressed to _refreshPersonalPlanPreview." --> PersonalPlanWidgetState_refreshPersonalPlanPreview_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Add a refresh action to <code>PersonalPlanWidget</code> so the personal plan preview can reshuffle without immediately repeating the current pair when another preview exists, while handling empty, one-item, and duplicate-item lists safely. Extend <code>AppLocalizations</code> for the new <code>refreshPersonalPlanTooltip</code> label so the header refresh button is localized in English, Arabic, and Hebrew.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/308?tool=ast&topic=Header+refresh>Header refresh</a>
        </td><td>Add the localized refresh button to the personal plan header and adjust the action row so controls stay anchored correctly in LTR and RTL layouts.<details><summary>Modified files (9)</summary><ul><li>lib/MainPageHelpers/personalPlanWidget.dart</li>
<li>lib/l10n/app_ar.arb</li>
<li>lib/l10n/app_en.arb</li>
<li>lib/l10n/app_he.arb</li>
<li>lib/l10n/app_localizations.dart</li>
<li>lib/l10n/app_localizations_ar.dart</li>
<li>lib/l10n/app_localizations_en.dart</li>
<li>lib/l10n/app_localizations_he.dart</li>
<li>test/MainPageHelpers/personal_plan_widget_layout_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(home): disable two...</td><td>August 01, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Implement UX gaps reme...</td><td>June 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/ClubhouseAmit/LivingPositively/308?tool=ast&topic=Preview+shuffle>Preview shuffle</a>
        </td><td>Update <code>PersonalPlanWidget</code> to refresh the visible preview by selecting a different candidate when possible, while keeping zero-, one-, and two-item lists stable and test-covered.<details><summary>Modified files (2)</summary><ul><li>lib/MainPageHelpers/personalPlanWidget.dart</li>
<li>test/MainPageHelpers/personal_plan_widget_layout_test.dart</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>lubacareer@gmail.com</td><td>fix(home): disable two...</td><td>August 01, 2026</td></tr>
<tr><td>Dekel@tovli.co.il</td><td>Implement UX gaps reme...</td><td>June 07, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/ClubhouseAmit/LivingPositively/308?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>